### PR TITLE
docs: Convert Spec doc to use includes from `types.ts` instead of hard-coding

### DIFF
--- a/types/src/types.ts
+++ b/types/src/types.ts
@@ -2,6 +2,7 @@
  * @title A2A
  */
 
+// --8<-- [start:AgentProvider]
 /**
  * Represents the service provider of an agent.
  */
@@ -11,7 +12,9 @@ export interface AgentProvider {
   /** Agent provider's URL. */
   url: string;
 }
+// --8<-- [end:AgentProvider]
 
+// --8<-- [start:AgentCapabilities]
 /**
  * Defines optional capabilities supported by an agent.
  */
@@ -23,7 +26,9 @@ export interface AgentCapabilities {
   /** true if the agent exposes status change history for tasks. */
   stateTransitionHistory?: boolean;
 }
+// --8<-- [end:AgentCapabilities]
 
+// --8<-- [start:AgentSkill]
 /**
  * Represents a unit of capability that an agent can perform.
  */
@@ -57,7 +62,9 @@ export interface AgentSkill {
   /** Supported mime types for output. */
   outputModes?: string[];
 }
+// --8<-- [end:AgentSkill]
 
+// --8<-- [start:AgentCard]
 /**
  * An AgentCard conveys key information:
  * - Overall details (version, name, description, uses)
@@ -109,7 +116,9 @@ export interface AgentCard {
    */
   supportsAuthenticatedExtendedCard?: boolean;
 }
+// --8<-- [end:AgentCard]
 
+// --8<-- [start:Task]
 export interface Task {
   /** Unique identifier for the task */
   id: string;
@@ -127,7 +136,9 @@ export interface Task {
   /** Event type */
   kind: "task";
 }
+// --8<-- [end:Task]
 
+// --8<-- [start:TaskStatus]
 /** TaskState and accompanying message. */
 export interface TaskStatus {
   state: TaskState;
@@ -139,7 +150,9 @@ export interface TaskStatus {
    * */
   timestamp?: string;
 }
+// --8<-- [end:TaskStatus]
 
+// --8<-- [start:TaskStatusUpdateEvent]
 /** Sent by server during sendStream or subscribe requests */
 export interface TaskStatusUpdateEvent {
   /** Task id */
@@ -157,7 +170,9 @@ export interface TaskStatusUpdateEvent {
     [key: string]: any;
   };
 }
+// --8<-- [end:TaskStatusUpdateEvent]
 
+// --8<-- [start:TaskArtifactUpdateEvent]
 /** Sent by server during sendStream or subscribe requests */
 export interface TaskArtifactUpdateEvent {
   /** Task id */
@@ -177,7 +192,9 @@ export interface TaskArtifactUpdateEvent {
     [key: string]: any;
   };
 }
+// --8<-- [end:TaskArtifactUpdateEvent]
 
+// --8<-- [start:TaskIdParams]
 /** Parameters containing only a task ID, used for simple task operations. */
 export interface TaskIdParams {
   /** Task id. */
@@ -186,13 +203,17 @@ export interface TaskIdParams {
     [key: string]: any;
   };
 }
+// --8<-- [end:TaskIdParams]
 
+// --8<-- [start:TaskQueryParams]
 /** Parameters for querying a task, including optional history length. */
 export interface TaskQueryParams extends TaskIdParams {
   /** Number of recent messages to be retrieved. */
   historyLength?: number;
 }
+// --8<-- [end:TaskQueryParams]
 
+// --8<-- [start:MessageSendConfiguration]
 /**Configuration for the send message request. */
 export interface MessageSendConfiguration {
   /** Accepted output modalities by the client. */
@@ -204,7 +225,9 @@ export interface MessageSendConfiguration {
   /** If the server should treat the client as a blocking request. */
   blocking?: boolean;
 }
+// --8<-- [end:MessageSendConfiguration]
 
+// --8<-- [start:MessageSendParams]
 /** Sent by the client to the agent as a request. May create, continue or restart a task. */
 export interface MessageSendParams {
   /** The message being sent to the server. */
@@ -216,7 +239,9 @@ export interface MessageSendParams {
     [key: string]: any;
   };
 }
+// --8<-- [end:MessageSendParams]
 
+// --8<-- [start:TaskState]
 /** Represents the possible states of a Task. */
 export enum TaskState {
   Submitted = "submitted",
@@ -229,7 +254,9 @@ export enum TaskState {
   AuthRequired = "auth-required",
   Unknown = "unknown",
 }
+// --8<-- [end:TaskState]
 
+// --8<-- [start:Artifact]
 /** Represents an artifact generated for a task. */
 export interface Artifact {
   /** Unique identifier for the artifact. */
@@ -245,7 +272,9 @@ export interface Artifact {
     [key: string]: any;
   };
 }
+// --8<-- [end:Artifact]
 
+// --8<-- [start:Message]
 /** Represents a single message exchanged between user and agent. */
 export interface Message {
   /** Message sender's role */
@@ -267,7 +296,9 @@ export interface Message {
   /** Event type */
   kind: "message";
 }
+// --8<-- [end:Message]
 
+// --8<-- [start:PartBase]
 /** Base properties common to all message parts. */
 export interface PartBase {
   /** Optional metadata associated with the part. */
@@ -275,7 +306,9 @@ export interface PartBase {
     [key: string]: any;
   };
 }
+// --8<-- [end:PartBase]
 
+// --8<-- [start:TextPart]
 /** Represents a text segment within parts.*/
 export interface TextPart extends PartBase {
   /** Part type - text for TextParts*/
@@ -283,7 +316,9 @@ export interface TextPart extends PartBase {
   /** Text content */
   text: string;
 }
+// --8<-- [end:TextPart]
 
+// --8<-- [start:FileBase]
 /** Represents the base entity for FileParts */
 export interface FileBase {
   /** Optional name for the file */
@@ -291,21 +326,27 @@ export interface FileBase {
   /** Optional mimeType for the file */
   mimeType?: string;
 }
+// --8<-- [end:FileBase]
 
+// --8<-- [start:FileWithBytes]
 /** Define the variant where 'bytes' is present and 'uri' is absent */
 export interface FileWithBytes extends FileBase {
   /** base64 encoded content of the file*/
   bytes: string;
   uri?: never;
 }
+// --8<-- [end:FileWithBytes]
 
+// --8<-- [start:FileWithUri]
 /** Define the variant where 'uri' is present and 'bytes' is absent  */
 export interface FileWithUri extends FileBase {
   /** URL for the File content */
   uri: string;
   bytes?: never;
 }
+// --8<-- [end:FileWithUri]
 
+// --8<-- [start:FilePart]
 /** Represents a File segment within parts.*/
 export interface FilePart extends PartBase {
   /** Part type - file for FileParts */
@@ -313,7 +354,9 @@ export interface FilePart extends PartBase {
   /** File content either as url or bytes */
   file: FileWithBytes | FileWithUri;
 }
+// --8<-- [end:FilePart]
 
+// --8<-- [start:DataPart]
 /** Represents a structured data segment within a message part. */
 export interface DataPart extends PartBase {
   /** Part type - data for DataParts */
@@ -324,10 +367,14 @@ export interface DataPart extends PartBase {
     [key: string]: any;
   };
 }
+// --8<-- [end:DataPart]
 
+// --8<-- [start:Part]
 /** Represents a part of a message, which can be text, a file, or structured data. */
 export type Part = TextPart | FilePart | DataPart;
+// --8<-- [end:Part]
 
+// --8<-- [start:PushNotificationAuthenticationInfo]
 /** Defines authentication details for push notifications. */
 export interface PushNotificationAuthenticationInfo {
   /** Supported authentication schemes - e.g. Basic, Bearer */
@@ -335,7 +382,9 @@ export interface PushNotificationAuthenticationInfo {
   /** Optional credentials */
   credentials?: string;
 }
+// --8<-- [end:PushNotificationAuthenticationInfo]
 
+// --8<-- [start:PushNotificationConfig]
 /**Configuration for setting up push notifications for task updates. */
 export interface PushNotificationConfig {
   /** URL for sending the push notifications. */
@@ -344,7 +393,9 @@ export interface PushNotificationConfig {
   token?: string;
   authentication?: PushNotificationAuthenticationInfo;
 }
+// --8<-- [end:PushNotificationConfig]
 
+// --8<-- [start:TaskPushNotificationConfig]
 /**Parameters for setting or getting push notification configuration for a task */
 export interface TaskPushNotificationConfig {
   /** Task id. */
@@ -352,7 +403,9 @@ export interface TaskPushNotificationConfig {
   /** Push notification configuration. */
   pushNotificationConfig: PushNotificationConfig;
 }
+// --8<-- [end:TaskPushNotificationConfig]
 
+// --8<-- [start:SecurityScheme]
 /**
  * Mirrors the OpenAPI Security Scheme Object
  * (https://swagger.io/specification/#security-scheme-object)
@@ -362,13 +415,17 @@ export type SecurityScheme =
   | HTTPAuthSecurityScheme
   | OAuth2SecurityScheme
   | OpenIdConnectSecurityScheme;
+// --8<-- [end:SecurityScheme]
 
+// --8<-- [start:SecuritySchemeBase]
 /** Base properties shared by all security schemes. */
 export interface SecuritySchemeBase {
   /** Description of this security scheme. */
   description?: string;
 }
+// --8<-- [end:SecuritySchemeBase]
 
+// --8<-- [start:APIKeySecurityScheme]
 /** API Key security scheme. */
 export interface APIKeySecurityScheme extends SecuritySchemeBase {
   type: "apiKey";
@@ -377,7 +434,9 @@ export interface APIKeySecurityScheme extends SecuritySchemeBase {
   /** The name of the header, query or cookie parameter to be used. */
   name: string;
 }
+// --8<-- [end:APIKeySecurityScheme]
 
+// --8<-- [start:HTTPAuthSecurityScheme]
 /** HTTP Authentication security scheme. */
 export interface HTTPAuthSecurityScheme extends SecuritySchemeBase {
   type: "http";
@@ -394,21 +453,27 @@ export interface HTTPAuthSecurityScheme extends SecuritySchemeBase {
    */
   bearerFormat?: string;
 }
+// --8<-- [end:HTTPAuthSecurityScheme]
 
+// --8<-- [start:OAuth2SecurityScheme]
 /** OAuth2.0 security scheme configuration. */
 export interface OAuth2SecurityScheme extends SecuritySchemeBase {
   type: "oauth2";
   /** An object containing configuration information for the flow types supported. */
   flows: OAuthFlows;
 }
+// --8<-- [end:OAuth2SecurityScheme]
 
+// --8<-- [start:OpenIdConnectSecurityScheme]
 /** OpenID Connect security scheme configuration. */
 export interface OpenIdConnectSecurityScheme extends SecuritySchemeBase {
   type: "openIdConnect";
   /** Well-known URL to discover the [[OpenID-Connect-Discovery]] provider metadata. */
   openIdConnectUrl: string;
 }
+// --8<-- [end:OpenIdConnectSecurityScheme]
 
+// --8<-- [start:OAuthFlows]
 /** Allows configuration of the supported OAuth Flows */
 export interface OAuthFlows {
   /** Configuration for the OAuth Authorization Code flow. Previously called accessCode in OpenAPI 2.0. */
@@ -420,7 +485,9 @@ export interface OAuthFlows {
   /** Configuration for the OAuth Resource Owner Password flow */
   password?: PasswordOAuthFlow;
 }
+// --8<-- [end:OAuthFlows]
 
+// --8<-- [start:AuthorizationCodeOAuthFlow]
 /** Configuration details for a supported OAuth Flow */
 export interface AuthorizationCodeOAuthFlow {
   /**
@@ -444,7 +511,9 @@ export interface AuthorizationCodeOAuthFlow {
    */
   scopes: { [name: string]: string };
 }
+// --8<-- [end:AuthorizationCodeOAuthFlow]
 
+// --8<-- [start:ClientCredentialsOAuthFlow]
 /** Configuration details for a supported OAuth Flow */
 export interface ClientCredentialsOAuthFlow {
   /**
@@ -463,7 +532,9 @@ export interface ClientCredentialsOAuthFlow {
    */
   scopes: { [name: string]: string };
 }
+// --8<-- [end:ClientCredentialsOAuthFlow]
 
+// --8<-- [start:ImplicitOAuthFlow]
 /** Configuration details for a supported OAuth Flow */
 export interface ImplicitOAuthFlow {
   /**
@@ -482,7 +553,9 @@ export interface ImplicitOAuthFlow {
    */
   scopes: { [name: string]: string };
 }
+// --8<-- [end:ImplicitOAuthFlow]
 
+// --8<-- [start:PasswordOAuthFlow]
 /** Configuration details for a supported OAuth Flow */
 export interface PasswordOAuthFlow {
   /**
@@ -501,7 +574,9 @@ export interface PasswordOAuthFlow {
    */
   scopes: { [name: string]: string };
 }
+// --8<-- [end:PasswordOAuthFlow]
 
+// --8<-- [start:JSONRPCMessage]
 /**
  * Base interface for any JSON-RPC 2.0 request or response.
  */
@@ -517,7 +592,9 @@ export interface JSONRPCMessage {
    */
   id?: number | string | null;
 }
+// --8<-- [end:JSONRPCMessage]
 
+// --8<-- [start:JSONRPCRequest]
 /**
  * Represents a JSON-RPC 2.0 Request object.
  */
@@ -532,7 +609,9 @@ export interface JSONRPCRequest extends JSONRPCMessage {
    */
   params?: { [key: string]: any };
 }
+// --8<-- [end:JSONRPCRequest]
 
+// --8<-- [start:JSONRPCError]
 /**
  * Represents a JSON-RPC 2.0 Error object.
  * This is typically included in a JSONRPCErrorResponse when an error occurs.
@@ -554,7 +633,9 @@ export interface JSONRPCError {
    */
   data?: any;
 }
+// --8<-- [end:JSONRPCError]
 
+// --8<-- [start:JSONRPCResult]
 /**
  * Represents a JSON-RPC 2.0 Result object.
  */
@@ -566,7 +647,9 @@ interface JSONRPCResult extends JSONRPCMessage {
 
   error?: never; // Optional 'never' helps enforce exclusivity
 }
+// --8<-- [end:JSONRPCResult]
 
+// --8<-- [start:JSONRPCErrorResponse]
 /**
  * Represents a JSON-RPC 2.0 Error Response object.
  */
@@ -574,7 +657,9 @@ export interface JSONRPCErrorResponse extends JSONRPCMessage {
   result?: never; // Optional 'never' helps enforce exclusivity
   error: JSONRPCError | A2AError;
 }
+// --8<-- [end:JSONRPCErrorResponse]
 
+// --8<-- [start:JSONRPCResponse]
 /**
  * Represents a JSON-RPC 2.0 Response object.
  */
@@ -585,7 +670,9 @@ export type JSONRPCResponse =
   | CancelTaskResponse
   | SetTaskPushNotificationConfigResponse
   | GetTaskPushNotificationConfigResponse;
+// --8<-- [end:JSONRPCResponse]
 
+// --8<-- [start:SendMessageRequest]
 /**
  * JSON-RPC request model for the 'message/send' method.
  */
@@ -593,21 +680,27 @@ export interface SendMessageRequest extends JSONRPCRequest {
   method: "message/send";
   params: MessageSendParams;
 }
+// --8<-- [end:SendMessageRequest]
 
+// --8<-- [start:SendMessageSuccessResponse]
 /**
  * JSON-RPC success response model for the 'message/send' method.
  */
 export interface SendMessageSuccessResponse extends JSONRPCResult {
   result: Message | Task;
 }
+// --8<-- [end:SendMessageSuccessResponse]
 
+// --8<-- [start:SendMessageResponse]
 /**
  * JSON-RPC response model for the 'message/send' method.
  */
 export type SendMessageResponse =
   | SendMessageSuccessResponse
   | JSONRPCErrorResponse;
+// --8<-- [end:SendMessageResponse]
 
+// --8<-- [start:SendStreamingMessageRequest]
 /**
  * JSON-RPC request model for the 'message/stream' method.
  */
@@ -615,21 +708,27 @@ export interface SendStreamingMessageRequest extends JSONRPCRequest {
   method: "message/stream";
   params: MessageSendParams;
 }
+// --8<-- [end:SendStreamingMessageRequest]
 
+// --8<-- [start:SendStreamingMessageSuccessResponse]
 /**
  * JSON-RPC success response model for the 'message/stream' method.
  */
 export interface SendStreamingMessageSuccessResponse extends JSONRPCResult {
   result: Message | Task | TaskStatusUpdateEvent | TaskArtifactUpdateEvent;
 }
+// --8<-- [end:SendStreamingMessageSuccessResponse]
 
+// --8<-- [start:SendStreamingMessageResponse]
 /**
  * JSON-RPC response model for the 'message/stream' method.
  */
 export type SendStreamingMessageResponse =
   | SendStreamingMessageSuccessResponse
   | JSONRPCErrorResponse;
+// --8<-- [end:SendStreamingMessageResponse]
 
+// --8<-- [start:GetTaskRequest]
 /**
  * JSON-RPC request model for the 'tasks/get' method.
  */
@@ -639,7 +738,9 @@ export interface GetTaskRequest extends JSONRPCRequest {
   /** A Structured value that holds the parameter values to be used during the invocation of the method. */
   params: TaskQueryParams;
 }
+// --8<-- [end:GetTaskRequest]
 
+// --8<-- [start:GetTaskSuccessResponse]
 /**
  * JSON-RPC success response for the 'tasks/get' method.
  */
@@ -647,12 +748,16 @@ export interface GetTaskSuccessResponse extends JSONRPCResult {
   /** The result object on success. */
   result: Task;
 }
+// --8<-- [end:GetTaskSuccessResponse]
 
+// --8<-- [start:GetTaskResponse]
 /**
  * JSON-RPC success response for the 'tasks/get' method.
  */
 export type GetTaskResponse = GetTaskSuccessResponse | JSONRPCErrorResponse;
+// --8<-- [end:GetTaskResponse]
 
+// --8<-- [start:CancelTaskRequest]
 /**
  * JSON-RPC request model for the 'tasks/cancel' method.
  */
@@ -662,7 +767,9 @@ export interface CancelTaskRequest extends JSONRPCRequest {
   /** A Structured value that holds the parameter values to be used during the invocation of the method. */
   params: TaskIdParams;
 }
+// --8<-- [end:CancelTaskRequest]
 
+// --8<-- [start:CancelTaskSuccessResponse]
 /**
  * JSON-RPC success response model for the 'tasks/cancel' method.
  */
@@ -670,14 +777,18 @@ export interface CancelTaskSuccessResponse extends JSONRPCResult {
   /** The result object on success. */
   result: Task;
 }
+// --8<-- [end:CancelTaskSuccessResponse]
 
+// --8<-- [start:CancelTaskResponse]
 /**
  * JSON-RPC response for the 'tasks/cancel' method.
  */
 export type CancelTaskResponse =
   | CancelTaskSuccessResponse
   | JSONRPCErrorResponse;
+// --8<-- [end:CancelTaskResponse]
 
+// --8<-- [start:SetTaskPushNotificationConfigRequest]
 /**
  * JSON-RPC request model for the 'tasks/pushNotificationConfig/set' method.
  */
@@ -687,7 +798,9 @@ export interface SetTaskPushNotificationConfigRequest extends JSONRPCRequest {
   /** A Structured value that holds the parameter values to be used during the invocation of the method. */
   params: TaskPushNotificationConfig;
 }
+// --8<-- [end:SetTaskPushNotificationConfigRequest]
 
+// --8<-- [start:SetTaskPushNotificationConfigSuccessResponse]
 /**
  * JSON-RPC success response model for the 'tasks/pushNotificationConfig/set' method.
  */
@@ -696,14 +809,18 @@ export interface SetTaskPushNotificationConfigSuccessResponse
   /** The result object on success. */
   result: TaskPushNotificationConfig;
 }
+// --8<-- [end:SetTaskPushNotificationConfigSuccessResponse]
 
+// --8<-- [start:SetTaskPushNotificationConfigResponse]
 /**
  * JSON-RPC response for the 'tasks/pushNotificationConfig/set' method.
  */
 export type SetTaskPushNotificationConfigResponse =
   | SetTaskPushNotificationConfigSuccessResponse
   | JSONRPCErrorResponse;
+// --8<-- [end:SetTaskPushNotificationConfigResponse]
 
+// --8<-- [start:GetTaskPushNotificationConfigRequest]
 /**
  * JSON-RPC request model for the 'tasks/pushNotificationConfig/get' method.
  */
@@ -713,7 +830,9 @@ export interface GetTaskPushNotificationConfigRequest extends JSONRPCRequest {
   /** A Structured value that holds the parameter values to be used during the invocation of the method. */
   params: TaskIdParams;
 }
+// --8<-- [end:GetTaskPushNotificationConfigRequest]
 
+// --8<-- [start:GetTaskPushNotificationConfigSuccessResponse]
 /**
  * JSON-RPC success response model for the 'tasks/pushNotificationConfig/get' method.
  */
@@ -722,14 +841,18 @@ export interface GetTaskPushNotificationConfigSuccessResponse
   /** The result object on success. */
   result: TaskPushNotificationConfig;
 }
+// --8<-- [end:GetTaskPushNotificationConfigSuccessResponse]
 
+// --8<-- [start:GetTaskPushNotificationConfigResponse]
 /**
  * JSON-RPC response for the 'tasks/pushNotificationConfig/set' method.
  */
 export type GetTaskPushNotificationConfigResponse =
   | GetTaskPushNotificationConfigSuccessResponse
   | JSONRPCErrorResponse;
+// --8<-- [end:GetTaskPushNotificationConfigResponse]
 
+// --8<-- [start:TaskResubscriptionRequest]
 /**
  * JSON-RPC request model for the 'tasks/resubscribe' method.
  */
@@ -739,7 +862,9 @@ export interface TaskResubscriptionRequest extends JSONRPCRequest {
   /** A Structured value that holds the parameter values to be used during the invocation of the method. */
   params: TaskIdParams;
 }
+// --8<-- [end:TaskResubscriptionRequest]
 
+// --8<-- [start:A2ARequest]
 /**
  * A2A supported request types
  */
@@ -751,7 +876,9 @@ export type A2ARequest =
   | SetTaskPushNotificationConfigRequest
   | GetTaskPushNotificationConfigRequest
   | TaskResubscriptionRequest;
+// --8<-- [end:A2ARequest]
 
+// --8<-- [start:JSONParseError]
 /**
  * JSON-RPC error indicating invalid JSON was received by the server.
  */
@@ -762,7 +889,9 @@ export interface JSONParseError extends JSONRPCError {
    */
   message: string;
 }
+// --8<-- [end:JSONParseError]
 
+// --8<-- [start:InvalidRequestError]
 /**
  * JSON-RPC error indicating the JSON sent is not a valid Request object.
  */
@@ -774,7 +903,9 @@ export interface InvalidRequestError extends JSONRPCError {
    */
   message: string;
 }
+// --8<-- [end:InvalidRequestError]
 
+// --8<-- [start:MethodNotFoundError]
 /**
  * JSON-RPC error indicating the method does not exist or is not available.
  */
@@ -786,7 +917,9 @@ export interface MethodNotFoundError extends JSONRPCError {
    */
   message: string;
 }
+// --8<-- [end:MethodNotFoundError]
 
+// --8<-- [start:InvalidParamsError]
 /**
  * JSON-RPC error indicating invalid method parameter(s).
  */
@@ -798,7 +931,9 @@ export interface InvalidParamsError extends JSONRPCError {
    */
   message: string;
 }
+// --8<-- [end:InvalidParamsError]
 
+// --8<-- [start:InternalError]
 /**
  * JSON-RPC error indicating an internal JSON-RPC error on the server.
  */
@@ -810,7 +945,9 @@ export interface InternalError extends JSONRPCError {
    */
   message: string;
 }
+// --8<-- [end:InternalError]
 
+// --8<-- [start:TaskNotFoundError]
 /**
  * A2A specific error indicating the requested task ID was not found.
  */
@@ -822,7 +959,9 @@ export interface TaskNotFoundError extends JSONRPCError {
    */
   message: string;
 }
+// --8<-- [end:TaskNotFoundError]
 
+// --8<-- [start:TaskNotCancelableError]
 /**
  * A2A specific error indicating the task is in a state where it cannot be canceled.
  */
@@ -834,7 +973,9 @@ export interface TaskNotCancelableError extends JSONRPCError {
    */
   message: string;
 }
+// --8<-- [end:TaskNotCancelableError]
 
+// --8<-- [start:PushNotificationNotSupportedError]
 /**
  * A2A specific error indicating the agent does not support push notifications.
  */
@@ -846,7 +987,9 @@ export interface PushNotificationNotSupportedError extends JSONRPCError {
    */
   message: string;
 }
+// --8<-- [end:PushNotificationNotSupportedError]
 
+// --8<-- [start:UnsupportedOperationError]
 /**
  * A2A specific error indicating the requested operation is not supported by the agent.
  */
@@ -858,7 +1001,9 @@ export interface UnsupportedOperationError extends JSONRPCError {
    */
   message: string;
 }
+// --8<-- [end:UnsupportedOperationError]
 
+// --8<-- [start:ContentTypeNotSupportedError]
 /**
  * A2A specific error indicating incompatible content types between request and agent capabilities.
  */
@@ -870,7 +1015,9 @@ export interface ContentTypeNotSupportedError extends JSONRPCError {
    */
   message: string;
 }
+// --8<-- [end:ContentTypeNotSupportedError]
 
+// --8<-- [start:InvalidAgentResponseError]
 /**
  * A2A specific error indicating agent returned invalid response for the current method
  */
@@ -882,7 +1029,9 @@ export interface InvalidAgentResponseError extends JSONRPCError {
    */
   message: string;
 }
+// --8<-- [end:InvalidAgentResponseError]
 
+// --8<-- [start:A2AError]
 export type A2AError =
   | JSONParseError
   | InvalidRequestError
@@ -895,3 +1044,4 @@ export type A2AError =
   | UnsupportedOperationError
   | ContentTypeNotSupportedError
   | InvalidAgentResponseError;
+// --8<-- [end:A2AError]


### PR DESCRIPTION
Prevents file from becoming out of date.