### PR TITLE
docs(langgraph): clarify location of __main__.py and test_client.py in app/

### DIFF
--- a/docs/tutorials/python/7-streaming-and-multiturn.md
+++ b/docs/tutorials/python/7-streaming-and-multiturn.md
@@ -24,7 +24,7 @@ This example features a "Currency Agent" that uses the Gemini model via LangChai
 
 ## Running the LangGraph Server
 
-Navigate to the `a2a-samples/samples/python/agents/langgraph/` directory in your terminal and ensure your virtual environment (from the SDK root) is activated.
+Navigate to the `a2a-samples/samples/python/agents/langgraph/app` directory in your terminal and ensure your virtual environment (from the SDK root) is activated.
 
 Start the LangGraph agent server:
 
@@ -36,7 +36,7 @@ This will start the server, usually on `http://localhost:10000`.
 
 ## Interacting with the LangGraph Agent
 
-Open a **new terminal window**, activate your virtual environment, and navigate to `a2a-samples/samples/python/agents/langgraph/`.
+Open a **new terminal window**, activate your virtual environment, and navigate to `a2a-samples/samples/python/agents/langgraph/app`.
 
 Run its test client:
 


### PR DESCRIPTION
The files __main__.py and test_client.py are located in a2a-samples/samples/python/agents/langgraph/app/, not in the root directory a2a-samples/samples/python/agents/langgraph/.

# Description

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/google-a2a/A2A/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [x] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format)
- [x] Appropriate docs were updated (if necessary)

Fixes #2 🦕
