### PR TITLE
fix: remove duplicated java_multiple_files option

### DIFF
--- a/specification/grpc/a2a.proto
+++ b/specification/grpc/a2a.proto
@@ -8,7 +8,6 @@ import "google/api/field_behavior.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 
-option java_multiple_files = true;
 option csharp_namespace = "A2a.V1";
 option go_package = "google.golang.org/a2a/v1";
 option java_multiple_files = true;


### PR DESCRIPTION
# Description

Remove duplicated `java_multiple_files` option on proto file.

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/google-a2a/A2A/blob/main/CONTRIBUTING.md).
- [ ] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [ ] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format)
- [ ] Appropriate docs were updated (if necessary)

BEGIN_COMMIT_OVERRIDE
chore: remove duplicated java_multiple_files option
END_COMMIT_OVERRIDE