### PR TITLE
chore: update minimum Python version in tutorial

### DIFF
--- a/docs/tutorials/python/2-setup.md
+++ b/docs/tutorials/python/2-setup.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Python 3.13 or higher.
+- Python 3.10 or higher.
 - Access to a terminal or command prompt.
 - Git, for cloning the repository.
 - A code editor (e.g., Visual Studio Code) is recommended.


### PR DESCRIPTION
Python A2A SDK now supports Python 3.10+

Tutorial still says 3.13+, updating to be more inclusive.
