### PR TITLE
docs: Fix recommended TLS version

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -83,7 +83,7 @@ For a comprehensive guide on enterprise security aspects, see [Enterprise-Ready 
 
 ### 4.1. Transport Security
 
-As stated in section 3.1, production deployments **MUST** use HTTPS. Implementations **SHOULD** use modern [TLS](https://datatracker.ietf.org/doc/html/rfc8446) configurations (TLS 1.2+ recommended) with strong cipher suites.
+As stated in section 3.1, production deployments **MUST** use HTTPS. Implementations **SHOULD** use modern [TLS](https://datatracker.ietf.org/doc/html/rfc8446) configurations (TLS 1.3+ recommended) with strong cipher suites.
 
 ### 4.2. Server Identity Verification
 


### PR DESCRIPTION
RFC 8446 points to TLS 1.3, but TLS 1.2 is recommended instead. TLS 1.3 should be the minimum recommended in this case.




