### PR TITLE
docs: improperly closed parenthesis in Task state description

### DIFF
--- a/docs/topics/life-of-a-task.md
+++ b/docs/topics/life-of-a-task.md
@@ -5,7 +5,7 @@ When a message is sent to an agent, it can choose to reply with either:
 - A stateless `Message`.
 - A stateful `Task` and zero or more `TaskStatusUpdateEvent` or `TaskArtifactUpdateEvent`.
 
-If the response is a `Message`, the interaction is completed. On the other hand, A `Task` will keep getting updated until it is in a interrupted state ()`input-required` or `auth-required`) or a terminal state (`completed`, `cancelled`, `rejected` or `failed`).
+If the response is a `Message`, the interaction is completed. On the other hand, A `Task` will keep getting updated until it is in a interrupted state (`input-required` or `auth-required`) or a terminal state (`completed`, `cancelled`, `rejected` or `failed`).
 
 ## Context
 


### PR DESCRIPTION
# Description

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/A2A/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [x] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format)
- [x] Appropriate docs were updated (if necessary)

This pull request fixes a small typo in the Task state description. 🦕
An extra closing parenthesis was placed incorrectly:

Before:
...until it is in a interrupted state ()input-required or auth-required)...

After:
...until it is in an interrupted state (input-required or auth-required)...

This change improves clarity and corrects the formatting of the sentence.