### PR TITLE
chore(spec): Add `@TJS-examples` to spec and add missing Union Types

### DIFF
--- a/specification/json/a2a.json
+++ b/specification/json/a2a.json
@@ -157,6 +157,9 @@
                 },
                 "description": {
                     "description": "A human-readable description of the agent. Used to assist users and\nother agents in understanding what the agent can do.",
+                    "examples": [
+                        "Agent that helps users with recipes and cooking."
+                    ],
                     "type": "string"
                 },
                 "documentationUrl": {
@@ -169,6 +172,9 @@
                 },
                 "name": {
                     "description": "Human readable name of the agent.",
+                    "examples": [
+                        "Recipe Agent"
+                    ],
                     "type": "string"
                 },
                 "preferredTransport": {
@@ -216,6 +222,9 @@
                 },
                 "version": {
                     "description": "The version of the agent - format is up to the provider.",
+                    "examples": [
+                        "1.0.0"
+                    ],
                     "type": "string"
                 }
             },
@@ -314,6 +323,11 @@
                 },
                 "examples": {
                     "description": "The set of example scenarios that the skill can perform.\nWill be used by the client as a hint to understand how the skill can be used.",
+                    "examples": [
+                        [
+                            "I need a recipe for bread"
+                        ]
+                    ],
                     "items": {
                         "type": "string"
                     },
@@ -343,6 +357,13 @@
                 },
                 "tags": {
                     "description": "Set of tagwords describing classes of capabilities for this specific skill.",
+                    "examples": [
+                        [
+                            "cooking",
+                            "customer support",
+                            "billing"
+                        ]
+                    ],
                     "items": {
                         "type": "string"
                     },
@@ -802,7 +823,7 @@
                             "$ref": "#/definitions/GetTaskPushNotificationConfigParams"
                         }
                     ],
-                    "description": "A Structured value that holds the parameter values to be used during the invocation of the method.\nTaskIdParams type is deprecated for this method"
+                    "description": "A Structured value that holds the parameter values to be used during the invocation of the method.\nTaskIdParams type is deprecated for this method use `GetTaskPushNotificationConfigParams` instead."
                 }
             },
             "required": [
@@ -1251,6 +1272,12 @@
                 },
                 {
                     "$ref": "#/definitions/GetTaskPushNotificationConfigSuccessResponse"
+                },
+                {
+                    "$ref": "#/definitions/ListTaskPushNotificationConfigSuccessResponse"
+                },
+                {
+                    "$ref": "#/definitions/DeleteTaskPushNotificationConfigSuccessResponse"
                 }
             ],
             "description": "Represents a JSON-RPC 2.0 Response object."
@@ -2206,6 +2233,9 @@
                 },
                 "timestamp": {
                     "description": "ISO 8601 datetime string when the status was recorded.",
+                    "examples": [
+                        "2023-10-27T10:00:00Z"
+                    ],
                     "type": "string"
                 }
             },

--- a/types/src/types.ts
+++ b/types/src/types.ts
@@ -753,7 +753,9 @@ export type JSONRPCResponse =
   | GetTaskResponse
   | CancelTaskResponse
   | SetTaskPushNotificationConfigResponse
-  | GetTaskPushNotificationConfigResponse;
+  | GetTaskPushNotificationConfigResponse
+  | ListTaskPushNotificationConfigResponse
+  | DeleteTaskPushNotificationConfigResponse;
 // --8<-- [end:JSONRPCResponse]
 
 // --8<-- [start:SendMessageRequest]
@@ -918,8 +920,9 @@ export interface GetTaskPushNotificationConfigRequest extends JSONRPCRequest {
   id: number | string;
   /** A String containing the name of the method to be invoked. */
   method: "tasks/pushNotificationConfig/get";
-  /** A Structured value that holds the parameter values to be used during the invocation of the method.
-   * TaskIdParams type is deprecated for this method
+  /**
+   * A Structured value that holds the parameter values to be used during the invocation of the method.
+   * TaskIdParams type is deprecated for this method use `GetTaskPushNotificationConfigParams` instead.
    */
   params: GetTaskPushNotificationConfigParams | TaskIdParams;
 }


### PR DESCRIPTION
- **Replaced `@example` with `@TJS-examples`**: All JSDoc `@example` tags have been converted to `@TJS-examples`, used by`typescript-json-schema` to generate example values.
- **Completed Union Types**: The `JSONRPCResponse` union type was incomplete. Added the missing `ListTaskPushNotificationConfigResponse` and `DeleteTaskPushNotificationConfigResponse` types to make it consistent with the defined request types.