### PR TITLE
feat(spec): Add AGENT_CARD_WELL_KNOWN_URI to spec

### DIFF
--- a/specification/json/a2a.json
+++ b/specification/json/a2a.json
@@ -70,11 +70,6 @@
             ],
             "description": "A2A supported request types"
         },
-        "AGENT_CARD_WELL_KNOWN_URI": {
-            "const": "/.well-known/agent.json",
-            "description": "The well-known URI at which an AgentCard should be hosted according to the A2A protocol.\nThis URI is used by clients to discover the agent's capabilities and metadata.",
-            "type": "string"
-        },
         "APIKeySecurityScheme": {
             "description": "API Key security scheme.",
             "properties": {
@@ -133,7 +128,7 @@
             "type": "object"
         },
         "AgentCard": {
-            "description": "An AgentCard conveys key information:\n- Overall details (version, name, description, uses)\n- Skills: A set of capabilities the agent can perform\n- Default modalities/content types supported by the agent.\n- Authentication requirements\n\nThe AgentCard SHOULD be hosted at the well-known URI specified by\n`AGENT_CARD_WELL_KNOWN_URI`.",
+            "description": "An AgentCard conveys key information:\n- Overall details (version, name, description, uses)\n- Skills: A set of capabilities the agent can perform\n- Default modalities/content types supported by the agent.\n- Authentication requirements\n\nThe AgentCard SHOULD be hosted at the well-known URI specified by the\n`WellKnownUris.AGENT_CARD_WELL_KNOWN_URI` constant (\"/.well-known/agent.json\").",
             "properties": {
                 "additionalInterfaces": {
                     "description": "Announcement of additional supported transports. Client can use any of\nthe supported transports.",
@@ -2338,6 +2333,20 @@
             "required": [
                 "code",
                 "message"
+            ],
+            "type": "object"
+        },
+        "WellKnownUris": {
+            "description": "Well-known URIs used in the A2A protocol.",
+            "properties": {
+                "AGENT_CARD_WELL_KNOWN_URI": {
+                    "const": "/.well-known/agent.json",
+                    "description": "The well-known URI at which an AgentCard should be hosted.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "AGENT_CARD_WELL_KNOWN_URI"
             ],
             "type": "object"
         }

--- a/specification/json/a2a.json
+++ b/specification/json/a2a.json
@@ -70,6 +70,11 @@
             ],
             "description": "A2A supported request types"
         },
+        "AGENT_CARD_WELL_KNOWN_URI": {
+            "const": "/.well-known/agent.json",
+            "description": "The well-known URI at which an AgentCard should be hosted according to the A2A protocol.\nThis URI is used by clients to discover the agent's capabilities and metadata.",
+            "type": "string"
+        },
         "APIKeySecurityScheme": {
             "description": "API Key security scheme.",
             "properties": {
@@ -128,7 +133,7 @@
             "type": "object"
         },
         "AgentCard": {
-            "description": "An AgentCard conveys key information:\n- Overall details (version, name, description, uses)\n- Skills: A set of capabilities the agent can perform\n- Default modalities/content types supported by the agent.\n- Authentication requirements",
+            "description": "An AgentCard conveys key information:\n- Overall details (version, name, description, uses)\n- Skills: A set of capabilities the agent can perform\n- Default modalities/content types supported by the agent.\n- Authentication requirements\n\nThe AgentCard SHOULD be hosted at the well-known URI specified by\n`AGENT_CARD_WELL_KNOWN_URI`.",
             "properties": {
                 "additionalInterfaces": {
                     "description": "Announcement of additional supported transports. Client can use any of\nthe supported transports.",

--- a/specification/json/a2a.json
+++ b/specification/json/a2a.json
@@ -2337,7 +2337,7 @@
             "type": "object"
         },
         "WellKnownUris": {
-            "description": "Well-known URIs used in the A2A protocol.",
+            "description": "Well-known URIs used in the A2A protocol.\nhttps://datatracker.ietf.org/doc/html/rfc8615",
             "properties": {
                 "AGENT_CARD_WELL_KNOWN_URI": {
                     "const": "/.well-known/agent.json",

--- a/types/src/types.ts
+++ b/types/src/types.ts
@@ -4,7 +4,7 @@
 
 /**
  * Well-known URIs used in the A2A protocol.
- * @see https://datatracker.ietf.org/doc/html/rfc8615
+ * https://datatracker.ietf.org/doc/html/rfc8615
  */
 export interface WellKnownUris {
   /**

--- a/types/src/types.ts
+++ b/types/src/types.ts
@@ -3,11 +3,15 @@
  */
 
 /**
- * The well-known URI at which an AgentCard should be hosted according to the A2A protocol.
- * This URI is used by clients to discover the agent's capabilities and metadata.
+ * Well-known URIs used in the A2A protocol.
  * @see https://datatracker.ietf.org/doc/html/rfc8615
  */
-export type AGENT_CARD_WELL_KNOWN_URI = "/.well-known/agent.json";
+export interface WellKnownUris {
+  /**
+   * The well-known URI at which an AgentCard should be hosted.
+   */
+  AGENT_CARD_WELL_KNOWN_URI: "/.well-known/agent.json";
+}
 
 // --8<-- [start:AgentProvider]
 /**
@@ -115,8 +119,8 @@ export interface AgentInterface {
  * - Default modalities/content types supported by the agent.
  * - Authentication requirements
  *
- * The AgentCard SHOULD be hosted at the well-known URI specified by
- * `AGENT_CARD_WELL_KNOWN_URI`.
+ * The AgentCard SHOULD be hosted at the well-known URI specified by the
+ * `WellKnownUris.AGENT_CARD_WELL_KNOWN_URI` constant ("/.well-known/agent.json").
  */
 export interface AgentCard {
   /**

--- a/types/src/types.ts
+++ b/types/src/types.ts
@@ -2,6 +2,13 @@
  * @title A2A
  */
 
+/**
+ * The well-known URI at which an AgentCard should be hosted according to the A2A protocol.
+ * This URI is used by clients to discover the agent's capabilities and metadata.
+ * @see https://datatracker.ietf.org/doc/html/rfc8615
+ */
+export type AGENT_CARD_WELL_KNOWN_URI = "/.well-known/agent.json";
+
 // --8<-- [start:AgentProvider]
 /**
  * Represents the service provider of an agent.
@@ -107,6 +114,9 @@ export interface AgentInterface {
  * - Skills: A set of capabilities the agent can perform
  * - Default modalities/content types supported by the agent.
  * - Authentication requirements
+ *
+ * The AgentCard SHOULD be hosted at the well-known URI specified by
+ * `AGENT_CARD_WELL_KNOWN_URI`.
  */
 export interface AgentCard {
   /**


### PR DESCRIPTION
Prevents usage of "Magic Strings" in SDKs, which supports better adherence to the recommended path for Agent Cards.

NOTE: This path might also need to be changed based on feedback in https://github.com/protocol-registries/well-known-uris/issues/66 so having a global constant would make this adjustment easier.

Fixes #816 🦕
