### PR TITLE
chore: enforce consistent sort order in workflow using LC_ALL=C

### DIFF
--- a/.github/workflows/sort-spelling-allowlist.yml
+++ b/.github/workflows/sort-spelling-allowlist.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Sort allow.txt
         run: |
-          sort -u -o .github/actions/spelling/allow.txt .github/actions/spelling/allow.txt
+          LC_ALL=C sort -u -o .github/actions/spelling/allow.txt .github/actions/spelling/allow.txt
 
       - name: Configure Git
         run: |
@@ -48,5 +48,5 @@ jobs:
       - name: Fail on fork with changes
         if: steps.git_status.outputs.changes == 'true' && github.event.pull_request.head.repo.full_name != github.repository
         run: |
-          echo "::error::The 'allow.txt' file is not sorted correctly. Please run 'sort -u -o .github/actions/spelling/allow.txt .github/actions/spelling/allow.txt' and commit the changes."
+          echo "::error::The 'allow.txt' file is not sorted correctly. Please run 'LC_ALL=C sort -u -o .github/actions/spelling/allow.txt .github/actions/spelling/allow.txt' and commit the changes."
           exit 1


### PR DESCRIPTION
# Description

This PR adds explicit locale setting `LC_ALL=C` to the `sort` command used in the GitHub workflow, ensuring consistent behavior across different operating systems.

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/A2A/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [x] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format)
- [x] Appropriate docs were updated (if necessary)

Fixes N/A 🦕
