### PR TITLE
feat!: Add mTLS to SecuritySchemes, add oauth2 metadata url field, allow Skills to specify Security

### DIFF
--- a/specification/grpc/a2a.proto
+++ b/specification/grpc/a2a.proto
@@ -371,6 +371,18 @@ message AgentCard {
   map<string, SecurityScheme> security_schemes = 8;
   // protolint:disable REPEATED_FIELD_NAMES_PLURALIZED
   // Security requirements for contacting the agent.
+  // This list can be seen as an OR of ANDs. Each object in the list describes
+  // one possible set of security requirements that must be present on a
+  // request. This allows specifying, for example, "callers must either use
+  // OAuth OR an API Key AND mTLS."
+  // Example:
+  // security {
+  //   schemes { key: "oauth" value { list: ["read"] } }
+  // }
+  // security {
+  //   schemes { key: "api-key" }
+  //   schemes { key: "mtls" }
+  // }
   repeated Security security = 9;
   // protolint:enable REPEATED_FIELD_NAMES_PLURALIZED
   // The set of interaction modes that the agent supports across all skills.
@@ -448,6 +460,12 @@ message AgentSkill {
   repeated string input_modes = 6;
   // Possible output modalities produced
   repeated string output_modes = 7;
+  // protolint:disable REPEATED_FIELD_NAMES_PLURALIZED
+  // Security schemes necessary for the agent to leverage this skill.
+  // As in the overall AgentCard.security, each entry in this list represents
+  // a possible security scheme, i.e. a logical OR for possible security
+  // requirements.
+  repeated Security security = 8;
 }
 
 message TaskPushNotificationConfig {
@@ -472,6 +490,7 @@ message SecurityScheme {
     HTTPAuthSecurityScheme http_auth_security_scheme = 2;
     OAuth2SecurityScheme oauth2_security_scheme = 3;
     OpenIdConnectSecurityScheme open_id_connect_security_scheme = 4;
+    MutualTlsSecurityScheme mtls_security_scheme = 5;
   }
 }
 
@@ -503,6 +522,9 @@ message OAuth2SecurityScheme {
   string description = 1;
   // An object containing configuration information for the flow types supported
   OAuthFlows flows = 2;
+  // URL to the oauth2 authorization server metadata
+  // [RFC8414](https://datatracker.ietf.org/doc/html/rfc8414). TLS is required.
+  string oauth2_metadata_url = 3;
 }
 
 message OpenIdConnectSecurityScheme {
@@ -511,6 +533,11 @@ message OpenIdConnectSecurityScheme {
   // Well-known URL to discover the [[OpenID-Connect-Discovery]] provider
   // metadata.
   string open_id_connect_url = 2;
+}
+
+message MutualTlsSecurityScheme {
+  // Description of this security scheme.
+  string description = 1;
 }
 
 message OAuthFlows {

--- a/specification/json/a2a.json
+++ b/specification/json/a2a.json
@@ -193,7 +193,20 @@
                     "description": "Information about the agent's service provider."
                 },
                 "security": {
-                    "description": "A list of security requirement objects that apply to all agent interactions. Each object\nlists security schemes that can be used. Follows the OpenAPI 3.0 Security Requirement Object.",
+                    "description": "A list of security requirement objects that apply to all agent interactions. Each object\nlists security schemes that can be used. Follows the OpenAPI 3.0 Security Requirement Object.\nThis list can be seen as an OR of ANDs. Each object in the list describes one possible\nset of security requirements that must be present on a request. This allows specifying,\nfor example, \"callers must either use OAuth OR an API Key AND mTLS.\"",
+                    "examples": [
+                        [
+                            {
+                                "oauth": [
+                                    "read"
+                                ]
+                            },
+                            {
+                                "api-key": [],
+                                "mtls": []
+                            }
+                        ]
+                    ],
                     "items": {
                         "additionalProperties": {
                             "items": {
@@ -361,6 +374,25 @@
                     "description": "The set of supported output MIME types for this skill, overriding the agent's defaults.",
                     "items": {
                         "type": "string"
+                    },
+                    "type": "array"
+                },
+                "security": {
+                    "description": "Security schemes necessary for the agent to leverage this skill.",
+                    "examples": [
+                        [
+                            {
+                                "google": [
+                                    "oidc"
+                                ]
+                            }
+                        ]
+                    ],
+                    "items": {
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "type": "object"
                     },
                     "type": "array"
                 },
@@ -1550,6 +1582,23 @@
             ],
             "type": "object"
         },
+        "MutualTLSSecurityScheme": {
+            "properties": {
+                "description": {
+                    "description": "An optional description for the security scheme.",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "mutualTLS",
+                    "description": "The type of the security scheme. Must be 'mutualTLS'.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "type"
+            ],
+            "type": "object"
+        },
         "OAuth2SecurityScheme": {
             "description": "Defines a security scheme using OAuth 2.0.",
             "properties": {
@@ -1560,6 +1609,10 @@
                 "flows": {
                     "$ref": "#/definitions/OAuthFlows",
                     "description": "An object containing configuration information for the supported OAuth 2.0 flows."
+                },
+                "oauth2MetadataUrl": {
+                    "description": "URL to the oauth2 authorization server metadata\n[RFC8414](https://datatracker.ietf.org/doc/html/rfc8414). TLS is required.",
+                    "type": "string"
                 },
                 "type": {
                     "const": "oauth2",
@@ -1749,6 +1802,9 @@
                 },
                 {
                     "$ref": "#/definitions/OpenIdConnectSecurityScheme"
+                },
+                {
+                    "$ref": "#/definitions/MutualTLSSecurityScheme"
                 }
             ],
             "description": "Defines a security scheme that can be used to secure an agent's endpoints.\nThis is a discriminated union type based on the OpenAPI 3.0 Security Scheme Object."

--- a/types/src/types.ts
+++ b/types/src/types.ts
@@ -90,6 +90,12 @@ export interface AgentSkill {
    * The set of supported output MIME types for this skill, overriding the agent's defaults.
    */
   outputModes?: string[];
+  /**
+   * Security schemes necessary for the agent to leverage this skill.
+   *
+   * @TJS-examples [[{"google": ["oidc"]}]]
+   */
+  security?: { [scheme: string]: string }[];
 }
 // --8<-- [end:AgentSkill]
 
@@ -316,7 +322,7 @@ export interface GetTaskPushNotificationConfigParams extends TaskIdParams {
 /**
  * Defines parameters for listing all push notification configurations associated with a task.
  */
-export interface ListTaskPushNotificationConfigParams extends TaskIdParams {}
+export interface ListTaskPushNotificationConfigParams extends TaskIdParams { }
 // --8<-- [end:ListTaskPushNotificationConfigParams]
 
 // --8<-- [start:DeleteTaskPushNotificationConfigParams]
@@ -590,7 +596,8 @@ export type SecurityScheme =
   | APIKeySecurityScheme
   | HTTPAuthSecurityScheme
   | OAuth2SecurityScheme
-  | OpenIdConnectSecurityScheme;
+  | OpenIdConnectSecurityScheme
+  | MutualTLSSecurityScheme;
 // --8<-- [end:SecurityScheme]
 
 // --8<-- [start:SecuritySchemeBase]
@@ -638,6 +645,13 @@ export interface HTTPAuthSecurityScheme extends SecuritySchemeBase {
 }
 // --8<-- [end:HTTPAuthSecurityScheme]
 
+// --8<-- [start:MutualTLSSecurityScheme]
+export interface MutualTLSSecurityScheme extends SecuritySchemeBase {
+  /** The type of the security scheme. Must be 'mutualTLS'. */
+  readonly type: "mutualTLS";
+}
+// --8<-- [end:MutualTLSSecurityScheme]
+
 // --8<-- [start:OAuth2SecurityScheme]
 /**
  * Defines a security scheme using OAuth 2.0.
@@ -647,6 +661,11 @@ export interface OAuth2SecurityScheme extends SecuritySchemeBase {
   readonly type: "oauth2";
   /** An object containing configuration information for the supported OAuth 2.0 flows. */
   flows: OAuthFlows;
+  /**
+   * URL to the oauth2 authorization server metadata
+   * [RFC8414](https://datatracker.ietf.org/doc/html/rfc8414). TLS is required.
+   */
+  oauth2MetadataUrl?: string;
 }
 // --8<-- [end:OAuth2SecurityScheme]
 

--- a/types/src/types.ts
+++ b/types/src/types.ts
@@ -172,6 +172,11 @@ export interface AgentCard {
   /**
    * A list of security requirement objects that apply to all agent interactions. Each object
    * lists security schemes that can be used. Follows the OpenAPI 3.0 Security Requirement Object.
+   * This list can be seen as an OR of ANDs. Each object in the list describes one possible
+   * set of security requirements that must be present on a request. This allows specifying,
+   * for example, "callers must either use OAuth OR an API Key AND mTLS."
+   *
+   * @TJS-examples [[{"oauth": ["read"]}, {"api-key": [], "mtls": []}]]
    */
   security?: { [scheme: string]: string[] }[];
   /**


### PR DESCRIPTION
# Description

This PR makes changes to our security representations in AgentCards:

1. Adds a new MutualTLSSecurityScheme type for indicating mTLS connection requirements. This matches the same field in the OpenAPI specification v3.1. This type is pretty lacking: there is no way to indicate any requirements on the certificate that is presented by the client. I expect we'll want to extend this in the future (for example, we may want to allow an agent to indicate that a SPIFFE certificate must be presented). For now, users are advised to put requirements in the description field.
2. Adds a field for specifying a URL for OAuth2 provider metadata. This is planned for OpenAPI Specification v3.2, which has not yet been released. This allows clients to fetch additional information about the OAuth provider, such as to discover if they support Dynamic Client Registration.
3. Allows AgentSkills to specify a `security` field. This allows agents to indicate security requirements for leveraging a particular skill.

I also clarified the usage and expectations for the `security` field in the base AgentCard.

This change is marked backwards incompatible due to the addition of the MutualTLSSecurityScheme, which adds a new type to an exhaustive enum (the security scheme `anyOf`).