### PR TITLE
docs: type reference in spec for `ListTaskPushNotificationConfigParams`

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -821,7 +821,7 @@ Retrieves the associated push notification configurations for a specified task. 
 A object for fetching the push notification configurations for a task.
 
 ```ts { .no-copy }
---8<-- "types/src/types.ts:ListTaskPushNotificationConfigRequest"
+--8<-- "types/src/types.ts:ListTaskPushNotificationConfigParams"
 ```
 
 ### 7.8. `tasks/pushNotificationConfig/delete`


### PR DESCRIPTION
# Description
Changes the type reference in 7.7.1 from `ListTaskPushNotificationConfigRequest` to `ListTaskPushNotificationConfigParams`

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/A2A/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [x] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format)
- [x] Appropriate docs were updated (if necessary)

Fixes #907
