### PR TITLE
docs: add a link to the .net a2a sdk to the list of available a2a sdks

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ As AI agents become more prevalent, their ability to interoperate is crucial for
     - [🐍 A2A Python SDK](https://github.com/a2aproject/a2a-python) `pip install a2a-sdk`
     - [🧑‍💻 A2A JS SDK](https://github.com/a2aproject/a2a-js) `npm install @a2a-js/sdk`
     - [☕️ A2A Java SDK](https://github.com/a2aproject/a2a-java) using maven
-    - [🔷 A2A .NET SDK](https://github.com/a2aproject/a2a-dotnet) using [NuGet](https://www.nuget.org/packages/A2A)
+    - [🔷 A2A .NET SDK](https://github.com/a2aproject/a2a-dotnet) using [NuGet](https://www.nuget.org/packages/A2A) `dotnet add package A2A`
 - 🎬 Use our [samples](https://github.com/a2aproject/a2a-samples) to see A2A in action
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ As AI agents become more prevalent, their ability to interoperate is crucial for
     - [🐍 A2A Python SDK](https://github.com/a2aproject/a2a-python) `pip install a2a-sdk`
     - [🧑‍💻 A2A JS SDK](https://github.com/a2aproject/a2a-js) `npm install @a2a-js/sdk`
     - [☕️ A2A Java SDK](https://github.com/a2aproject/a2a-java) using maven
+    - [🔷 A2A .NET SDK](https://github.com/a2aproject/a2a-dotnet) using [NuGet](https://www.nuget.org/packages/A2A)
 - 🎬 Use our [samples](https://github.com/a2aproject/a2a-samples) to see A2A in action
 
 ## Contributing


### PR DESCRIPTION
# Description
This PR adds a link to the .NET A2A SDK to the list of available A2A SDKs.

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/A2A/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [x] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format)
- [x] Appropriate docs were updated (if necessary)