### PR TITLE
chore: Update CODEOWNERS/GOVERNANCE with TSC

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,3 +11,7 @@ docs/                   @a2aproject/tech-writing
 .mkdocs.yml             @a2aproject/tech-writing
 README.md               @a2aproject/tech-writing
 requirements-docs.txt   @a2aproject/tech-writing
+specification/          @a2aproject/a2a-tsc
+types/                  @a2aproject/a2a-tsc
+docs/specification.md   @a2aproject/a2a-tsc
+GOVERNANCE.md           @a2aproject/a2a-tsc

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -2,10 +2,10 @@
 
 **The Agent to Agent project is governed by the Technical Steering Committee. The Committee has seven seats, each held by the following companies:**
 
-1. Google - Todd Segal, Principal Engineer - @ToddSegal
+1. Google - Todd Segal, Principal Engineer - [@ToddSegal](https://github.com/ToddSegal)
 2. Microsoft - Darrel Miller, Partner API Architect - [@darrelmiller](https://github.com/darrelmiller)
 3. Cisco - Luca Muscariello, Principal Engineer - [@muscariello](https://github.com/muscariello)
-4. Amazon Web Services - Nicholas Aldridge, Principal Engineer - [@000-000-000-000-000](https://www.linkedin.com/in/nicholas-aldridge-341162a4)
+4. Amazon Web Services - Nicholas Aldridge, Principal Engineer - [@000-000-000-000-000](https://github.com/000-000-000-000-000)
 5. Salesforce - Sam Sharaf, Sr. Director Product Management - [@samuelsharaf](https://github.com/samuelsharaf)
 6. ServiceNow - Sean Hughes, AI Ecosystem Director - [@hughesthe1st](https://github.com/hughesthe1st)
 7. SAP - TBD

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -2,10 +2,10 @@
 
 **The Agent to Agent project is governed by the Technical Steering Committee. The Committee has seven seats, each held by the following companies:**
 
-1. Google - Todd Segal, Principal Engineer - [@ToddSegal](https://github.com/ToddSegal)
+1. Google - Todd Segal, Principal Engineer - @ToddSegal
 2. Microsoft - Darrel Miller, Partner API Architect - [@darrelmiller](https://github.com/darrelmiller)
 3. Cisco - Luca Muscariello, Principal Engineer - [@muscariello](https://github.com/muscariello)
-4. Amazon Web Services - Nicholas Aldridge, Principal Engineer - [LinkedIn](https://www.linkedin.com/in/nicholas-aldridge-341162a4)
+4. Amazon Web Services - Nicholas Aldridge, Principal Engineer - [@000-000-000-000-000](https://www.linkedin.com/in/nicholas-aldridge-341162a4)
 5. Salesforce - Sam Sharaf, Sr. Director Product Management - [@samuelsharaf](https://github.com/samuelsharaf)
 6. ServiceNow - Sean Hughes, AI Ecosystem Director - [@hughesthe1st](https://github.com/hughesthe1st)
 7. SAP - TBD


### PR DESCRIPTION
Make TSC CODEOWNERS for Spec and add missing GitHub accounts to GOVERNANCE
