### PR TITLE
fix Image size and styling was not properly applied in markdown

### DIFF
--- a/docs/topics/key-concepts.md
+++ b/docs/topics/key-concepts.md
@@ -3,7 +3,7 @@
 The Agent2Agent (A2A) protocol is built around a set of core concepts that define how agents interact. Understanding these concepts is crucial for developing or integrating with A2A-compliant systems.
 
 ![A2A Actors showing a User, A2A Client, and A2A Server](../assets/a2a-actors.png){ width="70%" style="margin:20px auto;display:block;" }
-![Alt Text](image.png){ width="70%" style="margin:20px auto;display:block;" }
+
 
 ## Core Actors
 

--- a/docs/topics/key-concepts.md
+++ b/docs/topics/key-concepts.md
@@ -2,8 +2,7 @@
 
 The Agent2Agent (A2A) protocol is built around a set of core concepts that define how agents interact. Understanding these concepts is crucial for developing or integrating with A2A-compliant systems.
 
-![A2A Actors showing a User, A2A Client, and A2A Server](../assets/a2a-actors.png){ width="70%" style="margin:20px auto;display:block;" }
-
+<img src="../assets/a2a-actors.png" alt="A2A Actors showing a User, A2A Client (Client Agent), and A2A Server (Remote Agent)" width="70%" style="margin:20px auto;display:block;" />
 
 ## Core Actors
 

--- a/docs/topics/key-concepts.md
+++ b/docs/topics/key-concepts.md
@@ -2,7 +2,8 @@
 
 The Agent2Agent (A2A) protocol is built around a set of core concepts that define how agents interact. Understanding these concepts is crucial for developing or integrating with A2A-compliant systems.
 
-![A2A Actors showing a User, A2A Client (Client Agent), and A2A Server (Remote Agent)](../assets/a2a-actors.png){ width="70%" style="margin:20px auto;display:block;" }
+![A2A Actors showing a User, A2A Client, and A2A Server](../assets/a2a-actors.png){ width="70%" style="margin:20px auto;display:block;" }
+![Alt Text](image.png){ width="70%" style="margin:20px auto;display:block;" }
 
 ## Core Actors
 


### PR DESCRIPTION
# Description
The Image was not properly embedded into the docs file revealing the styling code in the readme
<img width="1159" height="629" alt="image" src="https://github.com/user-attachments/assets/9a21fb21-16af-48dc-a525-cf52f3666a26" />

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/A2A/blob/main/CONTRIBUTING.md).
- [ ] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [ ] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
