### PR TITLE
docs: fix links on documentation site

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -83,7 +83,7 @@ Agents **MAY** support JSON-RPC 2.0 transport. If implemented, it **MUST** confo
 
 Agents **MAY** support gRPC transport. If implemented, it **MUST** conform to these requirements:
 
-- **Protocol Definition**: **MUST** use the normative Protocol Buffers definition in [`specification/grpc/a2a.proto`](specification/grpc/a2a.proto).
+- **Protocol Definition**: **MUST** use the normative Protocol Buffers definition in [`specification/grpc/a2a.proto`](https://github.com/a2aproject/A2A/blob/main/specification/grpc/a2a.proto).
 - **Message Serialization**: **MUST** use Protocol Buffers version 3 for message serialization.
 - **Service Definition**: **MUST** implement the `A2AService` gRPC service as defined in the proto file.
 - **Method Coverage**: **MUST** provide all methods with functionally equivalent behavior to other supported transports.
@@ -1991,5 +1991,5 @@ Implementations **SHOULD** validate compliance through:
 - **Transport interoperability**: Test communication with agents using different transport implementations.
 - **Method mapping verification**: Verify that all supported transports use the correct method names and URL patterns as defined in [Section 3.5](#35-method-mapping-and-naming-conventions).
 - **Error handling**: Verify proper handling of all defined error conditions.
-- **Data format validation**: Ensure JSON schemas match the TypeScript type definitions in [`types/src/types.ts`](types/src/types.ts).
+- **Data format validation**: Ensure JSON schemas match the TypeScript type definitions in [`types/src/types.ts`](https://github.com/a2aproject/A2A/blob/main/types/src/types.ts).
 - **Multi-transport consistency**: For multi-transport agents, verify functional equivalence across all supported transports.

--- a/docs/topics/streaming-and-async.md
+++ b/docs/topics/streaming-and-async.md
@@ -29,7 +29,7 @@ For tasks that produce incremental results (like generating a long document or s
 Refer to the Protocol Specification for detailed structures:
 
 - [`message/stream`](../specification.md#72-messagestream)
-- [`tasks/resubscribe`](../specification.md#77-tasksresubscribe)
+- [`tasks/resubscribe`](../specification.md#79-tasksresubscribe)
 
 ## 2. Push Notifications for Disconnected Scenarios
 


### PR DESCRIPTION
There are a few links in the spec doc that are clearly meant to link to the github repo as the files they link to are outside the docs folder. This fixes them so they work on the generated site hosted at https://a2a-protocol.org/

Ideally we would use relative links so that when reading the markdown file in your IDE the links take you to the corresponding file within the repo. I tried setting up a redirect in mkdocs.yml but the locally running website kept downloading the file from github instead of navigating to it. There is probably some plugin that will make this work however for now I would like to simply fix the docs on the website.
