### PR TITLE
docs: update Old SDK Docs Link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -172,4 +172,4 @@ plugins:
         "tutorials/python/8-agent-capabilities.md": "tutorials/python/7-streaming-and-multiturn.md"
         "tutorials/python/9-ollama-agent.md": "tutorials/python/7-streaming-and-multiturn.md"
         "tutorials/python/10-next-steps.md": "tutorials/python/8-next-steps.md"
-        "sdk/python/": "sdk/python/api/index.html"
+        "sdk/python/": "sdk/python/api/"


### PR DESCRIPTION
Update the old SDK docs link from sdk/python/api/index.html to sdk/python/api/.

Fixes #951 
