### PR TITLE
docs - update specification to clarify web hook certificate verification

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -251,6 +251,7 @@ The A2A Server:
 - **MUST** authenticate every incoming request based on the provided HTTP credentials and its declared authentication requirements from its Agent Card.
 - **SHOULD** use standard HTTP status codes like [`401 Unauthorized`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401) or [`403 Forbidden`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403) for authentication challenges or rejections.
 - **SHOULD** include relevant HTTP headers (e.g., [`WWW-Authenticate`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/WWW-Authenticate)) with `401 Unauthorized` responses to indicate the required authentication scheme(s), guiding the client.
+- **SHOULD** authenticate the Client's webhook server identity, if provided, by validating its TLS certificate against trusted certificate authorities (CAs) during the TLS handshake.
 
 ### 4.5. In-Task Authentication (Secondary Credentials)
 


### PR DESCRIPTION
# Webhook Certificate Checks

## User Benefit
While it is specified that Clients SHOULD verify Server identity through the certificate, it is not currently explicit that Servers also have this responsibility when delivering an update to a web hook URL. It would be beneficial to users if uniform requirements on identity verification were explicitly specified. Having a variation in requirements that depends on whether responses are delivered synchronously or asynchronously is surprising and seems unintentional.
The risk involved in not confirming the web hook certificate includes a potential breach of confidentiality of response payload.

## This Change
This PR proposes an additional statement making explicit the A2A Server responsibility when delivering asynchronous payload updates to authenticate the destination certificate.

## Compatibility
In theory, a previously fully conforming implementation that did not perform a check on a web hook server certificate would not meet the new SHOULD statement. I couldn't locate information about what this implies eg. with respect to versioning.
In practice, it seems at least somewhat unlikely that implementations does this because verification of server certificates is the default behavior across many different software toolsets for some time.