### PR TITLE
fix(proto): Add icon_url to a2a.proto

### DIFF
--- a/specification/grpc/a2a.proto
+++ b/specification/grpc/a2a.proto
@@ -357,6 +357,8 @@ message AgentCard {
   // Announcement of additional supported transports. Client can use any of
   // the supported transports.
   repeated AgentInterface additional_interfaces = 15;
+  // An optional URL to an icon for the agent. 
+  string icon_url = 18;
   // The service provider of the agent.
   AgentProvider provider = 4;
   // The version of the agent.


### PR DESCRIPTION
# Description

According to the specification for `0.3.0` there is an optional icon url in AgentCard, however this is not present in the provided protobuf spec.

I didn't know which tag is preferred for this field, so I incremented the highest tag found.

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/A2A/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [ ] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
