### PR TITLE
chore(doc): Fix example typo in 9.2 Basic Execution

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1315,7 +1315,7 @@ _If the task were longer-running, the server might initially respond with `statu
      "jsonrpc": "2.0",
      "id": 1,
      "result": {
-       "messageId": "363422be-b0f9-4692-a24d-278670e7c7f1",
+       "messageId": "9229e770-767c-417b-a0b0-f0741243c589",
        "contextId": "c295ea44-7543-4f78-b524-7a38915ad6e4",
        "parts": [
          {


### PR DESCRIPTION
Message Ids dont match in the example

# Description

Message Ids dont match in the example. Just a small typo.

<img width="1622" height="1764" alt="image" src="https://github.com/user-attachments/assets/3f8eb94d-f03e-4aa5-8736-1ab5294832c1" />


- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/A2A/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [x] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format)
- [x] Appropriate docs were updated (if necessary)

Fixes #994 🦕
