### PR TITLE
fix: Revert "chore(gRPC): Update a2a.proto to include metadata on GetTaskRequest"

### DIFF
--- a/specification/grpc/a2a.proto
+++ b/specification/grpc/a2a.proto
@@ -637,8 +637,6 @@ message GetTaskRequest {
   string name = 1 [(google.api.field_behavior) = REQUIRED];
   // The number of most recent messages from the task's history to retrieve.
   int32 history_length = 2;
-  // Optional metadata for the request.
-  google.protobuf.Struct metadata = 3;
 }
 
 message CancelTaskRequest {


### PR DESCRIPTION
Reverts a2aproject/A2A#996

Fixes #1002 

GetTaskRequest in the REST protocol is a GET. GET does not have request body, and all fields in GET should be serializable to a query param. 

metadata when being a struct cannot be serialized to query param, and this is causing failure during API discovery doc generation `http: map field 'google.protobuf.Struct.fields' referred to by message 'a2a.v1.GetTaskRequest' cannot be mapped as an HTTP parameter.`