### PR TITLE
fix: Add missing metadata field to Part message in gRPC specification

### DIFF
--- a/specification/grpc/a2a.proto
+++ b/specification/grpc/a2a.proto
@@ -198,6 +198,8 @@ message Part {
     FilePart file = 2;
     DataPart data = 3;
   }
+  // Optional metadata associated with this part.
+  google.protobuf.Struct metadata = 4;
 }
 
 // FilePart represents the different ways files can be provided. If files are


### PR DESCRIPTION
## Summary
- Adds missing `metadata` field to the `Part` message in the gRPC specification
- Fixes inconsistency between TypeScript/JSON and gRPC protocol definitions
- Prevents data loss during Python ↔ gRPC conversions

## Problem
The `Part` message in `specification/grpc/a2a.proto` was missing the `metadata` field that exists in the TypeScript and Python specifications. This caused important metadata (like ADK function call/response types) to be lost during conversions between Python and gRPC representations.

## Solution
Added `google.protobuf.Struct metadata = 4;` to the `Part` message, following the same pattern used by other proto messages in the specification (Task, Message, Artifact, etc.).

Fixes #1005