### PR TITLE
fix(samples): replace missing requirements.txt with requirements-dev.txt

### DIFF
--- a/docs/tutorials/python/2-setup.md
+++ b/docs/tutorials/python/2-setup.md
@@ -41,7 +41,7 @@ We recommend using a virtual environment for Python projects. The A2A Python SDK
 2. **Install needed Python dependencies along with the A2A SDK and its dependencies:**
 
     ```bash
-    pip install -r samples/python/requirements.txt
+    pip install -r samples/python/requirements-dev.txt
     ```
 
 ## Verify Installation


### PR DESCRIPTION
# Description

The [a2a-samples](https://github.com/a2aproject/a2a-samples) project's example command doesn't work because there is no requirements.txt file. However, since a requirements-dev.txt file exists, the command has been updated to use it instead.


Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/A2A/blob/main/CONTRIBUTING.md).
> Although the following error is unrelated to my changes, I chose not to address it.
```
uvx ruff check
A001 Variable `copyright` is shadowing a Python builtin
 --> docs/sdk/python/conf.py:4:1
  |
3 | project = 'a2a-sdk'
4 | copyright = '2025, Google LLC'
  | ^^^^^^^^^
5 | author = 'Google LLC'
  |

Found 1 error.
```

- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [s] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format)
- [x] Appropriate docs were updated (if necessary)


Fixes #<issue_number_goes_here> 🦕
