### PR TITLE
fix(spec): Added normative content to specification.md that lived in topics 

### DIFF
--- a/docs/topics/agent-discovery.md
+++ b/docs/topics/agent-discovery.md
@@ -16,6 +16,8 @@ Client agents parse the Agent Card to determine if a remote agent is suitable fo
 
 ## Discovery Strategies
 
+Normative discovery elements (well-known location, Agent Card structure, conditional disclosure) are defined in [Spec §5](/specification/#5-agent-discovery-the-agent-card).
+
 Here are common strategies for how a client agent might discover the Agent Card of a remote agent:
 
 ### 1. Well-Known URI

--- a/docs/topics/enterprise-ready.md
+++ b/docs/topics/enterprise-ready.md
@@ -6,6 +6,8 @@ A key principle of A2A is that agents are typically "opaque" – they do not sha
 
 ## 1. Transport Level Security (TLS)
 
+Normative transport & authentication requirements live in the specification ([Spec §§3–5, 10.2, 16](/specification/)). This topic elaborates operational guidance.
+
 Ensuring the confidentiality and integrity of data in transit is fundamental.
 
 - **HTTPS Mandate:** All A2A communication in production environments **MUST** occur over HTTPS.

--- a/docs/topics/extensions.md
+++ b/docs/topics/extensions.md
@@ -2,7 +2,7 @@
 
 ## Abstract
 
-Extensions are a means of extending the Agent2Agent (A2A) protocol with new data, requirements, methods, and state machines. Agents declare their support for extensions in their [`AgentCard`](/specification/#5-agent-discovery-the-agent-card), and clients can then opt-in to the behavior offered by the extension as part of requests they make to the agent. Extensions are identified by a URI and defined by their extension specification. Anyone is able to define, publish, and implement an extension.
+Extensions are a means of extending the Agent2Agent (A2A) protocol with new data, requirements, methods, and state machines. Agents declare their support for extensions in their [`AgentCard`](/specification/#5-agent-discovery-the-agent-card), and clients can then opt-in to the behavior offered by the extension as part of requests they make to the agent. Extensions are identified by a URI and defined by their extension specification. Anyone is able to define, publish, and implement an extension. Normative rules are defined in the specification (see [Spec §12 Extensions](/specification/#12-extensions-normative)).
 
 ## Introduction
 
@@ -18,7 +18,7 @@ The exact set of possible ways to use extensions is intentionally not defined. T
 
 - Adding new RPC methods entirely. Extensions may define that the agent implements more than the core set of protocol methods. We refer to these as *method extensions*. For example, a ['task-history' extension](https://github.com/a2aproject/A2A/issues/585#:~:text=Details%20with%20an%20example) might add a `tasks/search` RPC method to retrieve a list of previous tasks.
 
-There are some changes to the protocol that extensions *do not* allow. These are:
+There are some changes to the protocol that extensions *do not* allow (see [Spec §12.3](/specification/#123-prohibited-changes) for normative wording). These are:
 
 - Changing the definition of core data structures. Adding new fields or removing required fields to protocol-defined data structures is not supported. Extensions are expected to place custom attributes in the `metadata` map that is present on core data structures.
 - Adding new values to enum types. Instead, extensions should use existing enum values and annotate additional semantic meaning in the `metadata` field.

--- a/docs/topics/life-of-a-task.md
+++ b/docs/topics/life-of-a-task.md
@@ -5,7 +5,7 @@ When a message is sent to an agent, it can choose to reply with either:
 - A stateless `Message`.
 - A stateful `Task` followed by zero or more `TaskStatusUpdateEvent` or `TaskArtifactUpdateEvent`.
 
-If the response is a `Message`, the interaction is completed. On the other hand, if the response is a `Task`, then the task will be processed by the agent, until it is in a interrupted state (`input-required` or `auth-required`) or a terminal state (`completed`, `cancelled`, `rejected` or `failed`).
+If the response is a `Message`, the interaction is completed. On the other hand, if the response is a `Task`, then the task will be processed by the agent, until it is in a interrupted state (`input-required` or `auth-required`) or a terminal state (`completed`, `cancelled`, `rejected` or `failed`). Normative refinement rules are captured in [Spec §13 Task Refinement & Follow-Ups](/specification/#13-task-refinement--follow-ups).
 
 ## Context
 

--- a/docs/topics/streaming-and-async.md
+++ b/docs/topics/streaming-and-async.md
@@ -6,7 +6,7 @@ The Agent2Agent (A2A) protocol is designed to handle tasks that may not complete
 
 For tasks that produce incremental results (like generating a long document or streaming media) or provide ongoing status updates, A2A supports real-time communication using Server-Sent Events (SSE). This is ideal when the client can maintain an active HTTP connection with the A2A Server.
 
-**Key Characteristics:**
+**Key Characteristics:** (See normative streaming & reconnection rules in [Spec §14 Streaming Semantics & Reconnection](/specification/#14-streaming-semantics--reconnection)).
 
 - **Initiation:** The client uses the `message/stream` RPC method to send an initial message (e.g., a prompt or command) and simultaneously subscribe to updates for that task.
 - **Server Capability:** The A2A Server must indicate its support for streaming by setting `capabilities.streaming: true` in its [Agent Card](../specification.md#552-agentcapabilities-object).
@@ -63,6 +63,8 @@ For very long-running tasks (e.g., lasting minutes, hours, or even days) or when
 - In enterprise or production settings, this is often a robust, secure service that handles incoming webhooks, authenticates callers, and routes messages (e.g., to a message queue, an internal API, a mobile push notification gateway, or another event-driven system).
 
 ### Security Considerations for Push Notifications
+
+Normative security requirements are centralized in [Spec §16 Push Notification Security](/specification/#16-push-notification-security-expanded). This section provides explanatory background.
 
 Security is paramount for push notifications due to their asynchronous and server-initiated outbound nature. Both the A2A Server (sending the notification) and the client's webhook receiver have responsibilities.
 


### PR DESCRIPTION
# Description

This PR attempts to add content to the specification.md file that currently is only mentioned in the topics section.

The text in this PR is primarily LLM generated and this PR is draft because it is only here for the purpose of getting TSC alignment on moving forward with this approach.

- [X] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/A2A/blob/main/CONTRIBUTING.md).
- [X] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [X] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format)
- [X] Appropriate docs were updated (if necessary)


