### PR TITLE
fix(grpc): make history_length optional

### DIFF
--- a/specification/grpc/a2a.proto
+++ b/specification/grpc/a2a.proto
@@ -119,9 +119,8 @@ message SendMessageConfiguration {
   repeated string accepted_output_modes = 1;
   // A configuration of a webhook that can be used to receive updates
   PushNotificationConfig push_notification = 2;
-  // The maximum number of messages to include in the history. if 0, the
-  // history will be unlimited.
-  int32 history_length = 3;
+  // The maximum number of messages to include in the history.
+  optional int32 history_length = 3;
   // If true, the message will be blocking until the task is completed. If
   // false, the message will be non-blocking and the task will be returned
   // immediately. It is the caller's responsibility to check for any task
@@ -705,7 +704,7 @@ message GetTaskRequest {
   // Format: tasks/{task_id}
   string name = 1 [(google.api.field_behavior) = REQUIRED];
   // The number of most recent messages from the task's history to retrieve.
-  int32 history_length = 2;
+  optional int32 history_length = 2;
 }
 // --8<-- [end:GetTaskRequest]
 


### PR DESCRIPTION
# Description

Both fields are optional in [types.ts](https://github.com/yarolegovich/A2A/blob/main/types/src/types.ts#L637) and [jsonrpc schema](https://github.com/a2aproject/A2A/blob/main/specification/json/a2a.json#L1683).
For both cases it might be useful to differentiate 0 and unset. For example:
1. A client calls GetTask and doesn't want History to be fetched / included in the response.
2. A client calls SendMessage and doesn't want history to be persisted at all.

The change is backward-compatible and makes it possible for a2a servers to provide consistent behavior regardless of the selected transport.