### PR TITLE
feat: Unique identifier for an agent in Agent Card

### DIFF
--- a/specification/grpc/a2a.proto
+++ b/specification/grpc/a2a.proto
@@ -2,6 +2,7 @@
 syntax = "proto3";
 package a2a.v1;
 
+import "buf/validate/validate.proto";
 import "google/api/annotations.proto";
 import "google/api/client.proto";
 import "google/api/field_behavior.proto";
@@ -457,6 +458,8 @@ message AgentCard {
   repeated AgentCardSignature signatures = 17;
   // An optional URL to an icon for the agent.
   optional string icon_url = 18;
+  // A stable unique identifier (UUID) for an agent, optional.
+  optional string id = 19 [(buf.validate.field).string.uuid = true];
 }
 // --8<-- [end:AgentCard]
 


### PR DESCRIPTION
- Adds a new id attribute to the agent card which must be a randomly generated UUID.
- This id must remain same for all versions of an agent.
- id is optional to support backward compatibility.
- Clients can reliably use id as the identifier if set in the agent card.

Fixes #1014 