### PR TITLE
Chore: update CODEOWNERS.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,12 +6,6 @@
 
 *                       @a2aproject/google-a2a-eng @a2aproject/a2a-tsc
 docs/                   @a2aproject/tech-writing
-*.md                    @a2aproject/tech-writing
-*.html                  @a2aproject/tech-writing
-.mkdocs/                @a2aproject/tech-writing
-.mkdocs.yml             @a2aproject/tech-writing
-README.md               @a2aproject/tech-writing
-requirements-docs.txt   @a2aproject/tech-writing
 specification/          @a2aproject/a2a-tsc
 types/                  @a2aproject/a2a-tsc
 docs/specification.md   @a2aproject/a2a-tsc

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,10 +4,10 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-*                       @a2aproject/google-a2a-eng @a2aproject/a2a-tsc
+*                       @a2aproject/a2a-tsc
 docs/                   @a2aproject/tech-writing
 specification/          @a2aproject/a2a-tsc
 types/                  @a2aproject/a2a-tsc
 docs/specification.md   @a2aproject/a2a-tsc
 GOVERNANCE.md           @a2aproject/a2a-tsc
-scripts/                @a2aproject/google-a2a-eng
+


### PR DESCRIPTION
Dropping a2aproject/google-a2a-eng and tech-writers from automatic reviewers list.
Keeping /docs for tech-writers but will consider making that optional. 