### PR TITLE
docs: Update Specification Documentation Release to only publish when a release is made

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -14,17 +14,18 @@
     ```
 {% endmacro %}
 
-??? note "**Latest Version** [`0.3.0`](../0.3.0/specification.md)"
+??? note "**Latest Version** [`0.3.0`](https://a2a-protocol.org/v0.3.0/specification)"
 
     **Previous Versions**
 
-    - [`0.2.5`](../0.2.5/specification.md)
-    - [`0.2.4`](../0.2.4/specification.md)
-    - [`0.2.3`](../0.2.3/specification.md)
-    - [`0.2.2`](../0.2.2/specification.md)
-    - [`0.2.1`](../0.2.1/specification.md)
-    - [`0.2.0`](../0.2.0/specification.md)
-    - [`0.1.0`](../0.1.0/specification.md)
+    - [`0.2.6`](https://a2a-protocol.org/v0.2.6/specification)
+    - [`0.2.5`](https://a2a-protocol.org/v0.2.5/specification)
+    - [`0.2.4`](https://a2a-protocol.org/v0.2.4/specification)
+    - [`0.2.3`](https://a2a-protocol.org/v0.2.3/specification)
+    - [`0.2.2`](https://a2a-protocol.org/v0.2.2/specification)
+    - [`0.2.1`](https://a2a-protocol.org/v0.2.1/specification)
+    - [`0.2.0`](https://a2a-protocol.org/v0.2.0/specification)
+    - [`0.1.0`](https://a2a-protocol.org/v0.1.0/specification)
 
 See [Release Notes](https://github.com/a2aproject/A2A/releases) for changes made between versions.
 


### PR DESCRIPTION
### Issues with this approach

- Style updates or link changes relating to other documentation pages won't be propagated to the specification doc when other pages are updated.

### Alternatives

- Maintain  copies of the specification docs for each minor version `0.X.0`
  - Similar to MCP Docs https://github.com/modelcontextprotocol/modelcontextprotocol/tree/main/docs/specification
  - This would also allow us to not use mike for versioning (would get rid of `latest` in URLs and could simplify SEO)
  
Follow-up to #1077