### PR TITLE
fix: Add reference_task_ids to Message proto.

### DIFF
--- a/specification/grpc/a2a.proto
+++ b/specification/grpc/a2a.proto
@@ -270,6 +270,9 @@ message Message {
   google.protobuf.Struct metadata = 6;
   // The URIs of extensions that are present or contributed to this Message.
   repeated string extensions = 7;
+  // A list of other task IDs that this message references for additional
+  // context.
+  repeated string reference_task_ids = 8;
 }
 // --8<-- [end:Message]
 


### PR DESCRIPTION
This field is present in the JSON Schema but not in the proto definition.

Fixes #1107 