### PR TITLE
Add Hector to A2A Protocol Integrations

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -80,6 +80,7 @@ These agentic frameworks have built-in A2A integration, making it easy to get st
 - [BeeAI Framework](https://framework.beeai.dev/integrations/a2a)
 - [LangGraph](https://docs.langchain.com/langgraph-platform/server-a2a)
 - [Pydantic AI](https://ai.pydantic.dev/a2a/)
+- [Hector](https://github.com/kadirpekel/hector)
 
 ## The Future is Interoperable
 


### PR DESCRIPTION
This PR adds Hector to the A2A integrations list. Hector is a pure A2A-native declarative AI agent platform written in Go that enables building powerful agents through YAML configuration alone, with zero code required. Unlike other frameworks that retrofit A2A support, Hector is built from the ground up on the A2A protocol specification, providing 100% compliance with agent discovery, task execution, streaming (SSE), and session management. Its unique value proposition is seamless integration of external A2A agents via simple YAML configuration (type: "a2a", url: "https://agent-url"), enabling true multi-agent orchestration across heterogeneous systems and demonstrating the full potential of A2A interoperability.

Repository: https://github.com/kadirpekel/hector

Would love to see Hector to the A2A integrations list if you also agree. I believe it demonstrates the protocol's potential for true agent interoperability.