### PR TITLE
fix(grpc): Add reference_task_ids field to Message for gRPC

### DIFF
--- a/specification/grpc/a2a.proto
+++ b/specification/grpc/a2a.proto
@@ -270,6 +270,8 @@ message Message {
   google.protobuf.Struct metadata = 6;
   // The URIs of extensions that are present or contributed to this Message.
   repeated string extensions = 7;
+  // A list of other task IDs that this message references for additional context.
+  repeated string reference_task_ids = 8;
 }
 // --8<-- [end:Message]
 


### PR DESCRIPTION
Add support for referencing other task IDs in messages to provide additional context. This aligns the gRPC specification with the JSON specification which already includes the referenceTaskIds field.

The new field is optional and backward compatible with existing implementations.