### PR TITLE
docs: add Content Integrity Profile v1 (optional artifact fields)

### DIFF
--- a/.github/spelling/allow.txt
+++ b/.github/spelling/allow.txt
@@ -1,4 +1,3 @@
-secp
 secp256k1
 ECDSA
 DER
@@ -7,4 +6,3 @@ kid
 sha256
 canonicalization
 provenance
-hexstring


### PR DESCRIPTION
Adds an optional “Content Integrity Profile v1” to A2A artifacts.

- Optional fields: `hash`, `signature { alg,value }`, `schemaRef`, `links[]`
- Portable verification (cross-org provenance, archival integrity, safer caching)
- Fully backward-compatible; existing clients/servers may ignore

Refs: #1140
Prior art: https://github.com/Phil-Hills/cube-protocol-spec

Closes #1140

