### PR TITLE
docs: Replace filename metadata label with name to align with FileBase prop…

### DIFF
--- a/docs/topics/key-concepts.md
+++ b/docs/topics/key-concepts.md
@@ -71,7 +71,7 @@ The primary part kinds are:
 
 - `TextPart`: Contains plain textual content.
 - `FilePart`: Represents a file. It can be transmitted either inline (Base64
-   encoded) or through a URI. It includes metadata like "filename" and "mimeType".
+   encoded) or through a URI. It includes metadata like "name" and "mimeType".
 - `DataPart`: Carries structured JSON data. This is useful for forms,
    parameters, or any machine-readable information.
 


### PR DESCRIPTION
## Problem
**The "filename” metadata label** in key-concept.md does not quite align with FileBase property. As indicated in the specification.md, name, mineType or bytes labels are part of the FilePart metadatas, instead of using filename label.

<img width="950" height="557" alt="image" src="https://github.com/user-attachments/assets/de687e31-e184-4036-a35b-763649bae682" />


## Solution
Replace “filename” metadata label with “name” label to align with FileBase property.


## Changes
Modify A2A\docs\topics\key-concepts.md and **replace “filename” metadata label with “name” label** to better align with FileBase property from specification.

## Testing
✅ Documentation builds successfully with mkdocs
✅ Markdown linting passes
✅ All internal anchor links verified
✅ No broken cross-references

## Issue
Fixes #1167