### PR TITLE
feat(spec): Natively Support Multi-tenancy on gRPC through an additional scope field on the request.

### DIFF
--- a/specification/grpc/a2a.proto
+++ b/specification/grpc/a2a.proto
@@ -45,8 +45,7 @@ service A2AService {
     option (google.api.http) = {
       get: "/v1/{name=tasks/*}"
       additional_bindings: {
-        post: "/{tenant}/v1/{name=tasks/*}"
-        body: "*"
+        get: "/{tenant}/v1/{name=tasks/*}"
       }
     };
     option (google.api.method_signature) = "name";


### PR DESCRIPTION
Add scope field to the requests and AgentInterface, deprecate the three fields defining transports in favor of a new supported_interfaces field.

fixes #1148