### PR TITLE
feat(spec): Introduce native Pub/Sub primitives for scalable multi-agent collaboration

### DIFF
--- a/specification/a2a.proto
+++ b/specification/a2a.proto
@@ -138,24 +138,36 @@ service A2AService {
     option (google.api.method_signature) = "task_id,id";
   }
   // Publish a message to a topic.
-  rpc Publish(PublishRequest) returns (google.protobuf.Empty) {
+  rpc PublishMessage(PublishMessageRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
-      post: "/v1/publish"
+      post: "/message:publish"
       body: "*"
+      additional_bindings: {
+        post: "/{tenant}/message:publish"
+        body: "*"
+      }
     };
   }
-  // Subscribe to a set of topics.
-  rpc Subscribe(SubscribeRequest) returns (google.protobuf.Empty) {
+  // Subscribe messages from a set of topics.
+  rpc SubscribeMessage(SubscribeMessageRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
-      post: "/v1/subscribe"
+      post: "/message:subscribe"
       body: "*"
+      additional_bindings: {
+        post: "/{tenant}/message:subscribe"
+        body: "*"
+      }
     };
   }
-  // Unsubscribe a set of topics.
-  rpc Unsubscribe(UnsubscribeRequest) returns (google.protobuf.Empty) {
+  // Unsubscribe messages from a set of topics.
+  rpc UnsubscribeMessage(UnsubscribeMessageRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
-      post: "/v1/unsubscribe"
+      post: "/message:unsubscribe"
       body: "*"
+      additional_bindings: {
+        post: "/{tenant}/message:unsubscribe"
+        body: "*"
+      }
     };
   }
 }
@@ -783,8 +795,8 @@ message GetExtendedAgentCardRequest {
   string tenant = 1;
 }
 
-// Represents a request for the `publish` method.
-message PublishRequest {
+// Represents a request for the `PublishMessage` method.
+message PublishMessageRequest {
   // The target topic for the message.
   string topic = 1 [(google.api.field_behavior) = REQUIRED];
   // The content of the message. The structure of the payload is contractually defined by the topic itself and is opaque to the runtime.
@@ -794,17 +806,17 @@ message PublishRequest {
   google.protobuf.Struct metadata = 3;
 }
 
-// Represents a request for the `subscribe` method.
-message SubscribeRequest {
-  // The target topics to subscribe.
+// Represents a request for the `SubscribeMessage` method.
+message SubscribeMessageRequest {
+  // The target topics to subscribe messages from.
   repeated string topics = 1 [(google.api.field_behavior) = REQUIRED];
   // Optional metadata for extensions.
   google.protobuf.Struct metadata = 2;
 }
 
-// Represents a request for the `unsubscribe` method.
-message UnsubscribeRequest {
-  // The target topics to unsubscribe.
+// Represents a request for the `UnsubscribeMessage` method.
+message UnsubscribeMessageRequest {
+  // The target topics to unsubscribe messages from.
   repeated string topics = 1 [(google.api.field_behavior) = REQUIRED];
   // Optional metadata for extensions.
   google.protobuf.Struct metadata = 2;

--- a/specification/a2a.proto
+++ b/specification/a2a.proto
@@ -137,6 +137,27 @@ service A2AService {
     };
     option (google.api.method_signature) = "task_id,id";
   }
+  // Publish a message to a topic.
+  rpc Publish(PublishRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      post: "/v1/publish"
+      body: "*"
+    };
+  }
+  // Subscribe to a set of topics.
+  rpc Subscribe(SubscribeRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      post: "/v1/subscribe"
+      body: "*"
+    };
+  }
+  // Unsubscribe a set of topics.
+  rpc Unsubscribe(UnsubscribeRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      post: "/v1/unsubscribe"
+      body: "*"
+    };
+  }
 }
 
 // Configuration of a send message request.
@@ -412,6 +433,8 @@ message AgentCapabilities {
   repeated AgentExtension extensions = 3;
   // Indicates if the agent supports providing an extended agent card when authenticated.
   optional bool extended_agent_card = 4;
+  // Indicates if the agent supports publishing and subscribing.
+  optional bool pubsub = 5;
 }
 
 // A declaration of a protocol extension supported by an Agent.
@@ -758,6 +781,33 @@ message ListTaskPushNotificationConfigsRequest {
 message GetExtendedAgentCardRequest {
   // Optional. Tenant ID, provided as a path parameter.
   string tenant = 1;
+}
+
+// Represents a request for the `publish` method.
+message PublishRequest {
+  // The target topic for the message.
+  string topic = 1 [(google.api.field_behavior) = REQUIRED];
+  // The content of the message. The structure of the payload is contractually defined by the topic itself and is opaque to the runtime.
+  // To promote interoperability, it is highly recommended that this payload conforms to a standard event envelope format, such as the CloudEvents specification.
+  google.protobuf.Struct payload = 2 [(google.api.field_behavior) = REQUIRED];
+  // Optional metadata for extensions.
+  google.protobuf.Struct metadata = 3;
+}
+
+// Represents a request for the `subscribe` method.
+message SubscribeRequest {
+  // The target topics to subscribe.
+  repeated string topics = 1 [(google.api.field_behavior) = REQUIRED];
+  // Optional metadata for extensions.
+  google.protobuf.Struct metadata = 2;
+}
+
+// Represents a request for the `unsubscribe` method.
+message UnsubscribeRequest {
+  // The target topics to unsubscribe.
+  repeated string topics = 1 [(google.api.field_behavior) = REQUIRED];
+  // Optional metadata for extensions.
+  google.protobuf.Struct metadata = 2;
 }
 
 // Represents the response for the `SendMessage` method.


### PR DESCRIPTION
**A Note on the "Runtime"**
Throughout this proposal, the term "runtime" is used to describe the logical entity responsible for managing topics, handling subscriptions, and routing EventMessages from publishers to subscribers. It's crucial to understand that this "runtime" is an abstract role within the Pub/Sub pattern, not a prescribed component of the A2A protocol itself.

We refer to the concrete implementation of this role as the Runtime.

The A2A protocol deliberately does not dictate how this Runtime should be implemented. The choice of implementation is left to the system architect and depends entirely on the specific requirements of their environment. For instance, the Runtime could be:

A dedicated, standalone Agent that programmatically manages topics and subscriber lists.

A facade layer built on top of mature, battle-tested message queuing infrastructure such as RocketMQ, Kafka, or cloud-native services like AWS SNS/SQS or Google Cloud Pub/Sub.

Our strong recommendation is to leverage existing message queue infrastructure to fulfill the Runtime's responsibilities. This approach allows developers to benefit from the scalability, reliability, and rich feature sets of these specialized systems, while the A2A protocol remains focused on defining the interoperable contract for agent-to-agent communication.

In essence, the A2A protocol defines the language agents use to talk about Pub/Sub; the Runtime is the engine that makes the conversation happen.

**Context & Motivation**
The current A2A specification is built on a powerful point-to-point (P2P) model. This is excellent for direct request/response interactions. However, building scalable and resilient multi-agent systems requires a decoupled, event-driven communication pattern, for which Publish/Subscribe (Pub/Sub) is the standard.

Analysis of community examples and our production practice demonstrates that developers must currently implement a fragile, inefficient, and centralized "router" actor in the application layer to simulate Pub/Sub. This approach introduces a single point of failure and a performance bottleneck, while pushing infrastructure concerns (message routing) onto the developer.

To enable true multi-agent autonomy and system evolvability, Pub/Sub should be a first-class citizen in the A2A protocol.
Having comprehensively analyzed the prevailing specifications, We found that current A2A specification provides three well-defined communication patterns:

- RPC (Remote Procedure Call): Command-oriented requests for managing Task lifecycles (e.g., GetTaskRequest, CancelTaskRequest).

- Stateful Object Observation (Webhooks): A mechanism to subscribe to state changes of a single resource instance (e.g., SetTaskPushNotificationConfigRequest).

- Conversational Messaging: A direct, 1-to-1, request/response paradigm for interactive dialogue (SendMessageRequest).

These patterns serve their purpose well but lack a native mechanism for broadcasting information to a dynamic set of interested parties in a decoupled manner. This PR introduces the Pub/Sub pattern to fill this architectural gap, enabling use cases like system-wide alerts, real-time data feeds, and multi-service event notifications.

Fixes #1029