### PR TITLE
feat(spec): Remove v1s from a2a url http bindings.

### DIFF
--- a/specification/grpc/a2a.proto
+++ b/specification/grpc/a2a.proto
@@ -716,10 +716,6 @@ message SendMessageRequest {
     (google.api.field_behavior) = REQUIRED,
     json_name = "message"
   ];
-  Message request = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    json_name = "message"
-  ];
   // Configuration for the send request.
   SendMessageConfiguration configuration = 2;
   // A flexible key-value map for passing additional context or parameters.
@@ -822,7 +818,6 @@ message SetTaskPushNotificationConfigRequest {
   // The ID for the new config.
   string config_id = 2 [(google.api.field_behavior) = REQUIRED];
   // The configuration to create.
-  TaskPushNotificationConfig config = 3 [(google.api.field_behavior) = REQUIRED];
   TaskPushNotificationConfig config = 3 [(google.api.field_behavior) = REQUIRED];
 }
 // --8<-- [end:SetTaskPushNotificationConfigRequest]


### PR DESCRIPTION
these can still be part of the agent card.

fixes #1268

built on top of https://github.com/a2aproject/A2A/pull/1195

BEGIN_COMMIT_OVERRIDE
feat(spec)!: Remove v1s from a2a url http bindings

Release-As: 1.0.0
END_COMMIT_OVERRIDE