### PR TITLE
fix(spec)!: Remove deprecated fields from a2a.proto for v1.0 release

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1926,22 +1926,13 @@ The AgentCard **MUST** properly declare supported protocols:
 - Each interface **MUST** accurately declare its transport protocol and URL
 - URLs **MAY** be reused if multiple transports are available at the same endpoint
 
-**Backward Compatibility:**
-
-For backward compatibility, agents **MAY** continue to populate the deprecated fields (`url`, `preferredTransport`, `additionalInterfaces`) alongside `supportedInterfaces`:
-
-- The `url` field **SHOULD** match the URL of the first entry in `supportedInterfaces`
-- The `preferredTransport` field **SHOULD** match the transport of the first entry in `supportedInterfaces`
-- The `additionalInterfaces` field **SHOULD** contain all entries from `supportedInterfaces`
-
 #### 8.3.2. Client Protocol Selection
 
 Clients **MUST** follow these rules:
 
-1. **Modern Clients**: Parse `supportedInterfaces` if present, and select the first supported transport
-2. **Legacy Clients**: Parse `url`/`preferredTransport` and `additionalInterfaces` for backward compatibility
-3. Prefer earlier entries in the ordered list when multiple options are supported
-4. Use the correct URL for the selected transport
+1. Parse `supportedInterfaces` if present, and select the first supported transport
+2. Prefer earlier entries in the ordered list when multiple options are supported
+3. Use the correct URL for the selected transport
 
 ### 8.4. Agent Card Signing
 

--- a/specification/grpc/a2a.proto
+++ b/specification/grpc/a2a.proto
@@ -419,7 +419,7 @@ message AgentCard {
   // Example: "Agent that helps users with recipes and cooking."
   string description = 2 [(google.api.field_behavior) = REQUIRED];
   // Ordered list of supported interfaces. First entry is preferred.
-  repeated AgentInterface supported_interfaces = 19;
+  repeated AgentInterface supported_interfaces = 19 [(google.api.field_behavior) = REQUIRED];
   // The service provider of the agent.
   AgentProvider provider = 4;
   // The version of the agent.

--- a/specification/grpc/a2a.proto
+++ b/specification/grpc/a2a.proto
@@ -420,12 +420,6 @@ message AgentCard {
   string description = 2 [(google.api.field_behavior) = REQUIRED];
   // Ordered list of supported interfaces. First entry is preferred.
   repeated AgentInterface supported_interfaces = 19;
-  // DEPRECATED: Use 'supported_interfaces' instead.
-  optional string url = 3 [deprecated = true];
-  // DEPRECATED: Use 'supported_interfaces' instead.
-  optional string preferred_transport = 14 [deprecated = true];
-  // DEPRECATED: Use 'supported_interfaces' instead.
-  repeated AgentInterface additional_interfaces = 15 [deprecated = true];
   // The service provider of the agent.
   AgentProvider provider = 4;
   // The version of the agent.

--- a/specification/grpc/a2a.proto
+++ b/specification/grpc/a2a.proto
@@ -408,6 +408,9 @@ message AgentInterface {
 // communication methods, and security requirements.
 // Next ID: 20
 message AgentCard {
+  // Reserve these field numbers as they were previously used by removed
+  // fields.
+  reserved 3, 14, 15;
   // The version of the A2A protocol this agent supports.
   // Default: "1.0"
   optional string protocol_version = 16 [(google.api.field_behavior) = REQUIRED];


### PR DESCRIPTION
As v1.0 is a major release and may contain breaking changes this commit cleans up the deprecated fields in the a2a.proto and references to this in the spec doc.

Closes: #1227