### PR TITLE
docs: fix typos in `specification.md`

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -142,7 +142,7 @@ Centering the proto file as the normative source ensures protocol neutrality, re
 
 ### 2.1. Requirements Language
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
+The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
 
 ### 2.2. Core Concepts
 
@@ -507,7 +507,7 @@ As service parameter names MAY need to co-exist with other parameters defined by
 
 - **Get operations** (Get Task, List Tasks, Get Extended Agent Card) are naturally idempotent
 - **Send Message** operations MAY be idempotent. Agents may utilize the messageId to detect duplicate messages.
-- **Cancel Task** operations are idempotent - multiple cancellation requests have the same effect. A duplicate cancellation request MAY return `TaskNotFoundError` if a the task has already been canceled and purged.
+- **Cancel Task** operations are idempotent - multiple cancellation requests have the same effect. A duplicate cancellation request MAY return `TaskNotFoundError` if the task has already been canceled and purged.
 
 #### 3.3.2. Error Handling
 
@@ -854,7 +854,7 @@ For detailed security guidance on push notifications, see [Section 13.2 Push Not
 {{ proto_to_table("specification/grpc/a2a.proto", "AgentCard") }}
 
 - **`protocolVersion`** (required, string): The version of the A2A protocol this agent supports (e.g., "1.0"). Defaults to "1.0".
-- **`name`** (required, string): A human readable name for the agent.
+- **`name`** (required, string): A human-readable name for the agent.
 - **`description`** (required, string): A human-readable description of the agent, assisting users and other agents in understanding its purpose.
 - **`supportedInterfaces`** (optional, array of [`AgentInterface`](#446-agentinterface)): An ordered list of supported interfaces (protocol binding and URL combinations). The first item in the list is the preferred interface that clients should use when possible. Clients can select any interface from this list based on their preferences, but SHOULD prefer earlier entries when multiple options are supported.
 - **`provider`** (optional, [`AgentProvider`](#442-agentprovider)): The service provider of the agent.


### PR DESCRIPTION
Hi,
Recent changes in in specification.md brought some typos: this PR fixes them.
See commit diffs for details.
Didier