### PR TITLE
docs: Remove legacy link to deleted Python SDK page, make "SDK Reference" left nav a single page link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,8 +43,7 @@ nav:
   - Specification:
       - Overview: specification.md
       - Protocol Definition: definitions.md
-  - SDK Reference:
-      - sdk/index.md
+  - SDK Reference: sdk/index.md
   - Community: community.md
   - Partners: partners.md
   - Roadmap: roadmap.md


### PR DESCRIPTION
The Python-specific SDK page was deleted in https://github.com/a2aproject/A2A/commit/75b68394df55993f9c7bff6d0dded62bb8677fe4