### PR TITLE
docs: fix broken link to deleted Python SDK page, redirect to main SDK page.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,7 +43,9 @@ nav:
   - Specification:
       - Overview: specification.md
       - Protocol Definition: definitions.md
-  - SDK Reference: sdk/index.md
+  - SDK Reference:
+      - sdk/index.md
+      - Python: sdk/python/api/index.html
   - Community: community.md
   - Partners: partners.md
   - Roadmap: roadmap.md
@@ -161,7 +163,7 @@ plugins:
         "specification/topics/push_notifications.md": "topics/streaming-and-async.md"
         "topics/index.md": "topics/what-is-a2a.md"
         "topics/roadmap.md": "roadmap.md"
-        "sdk/python.md": "sdk/index.md"
+        "sdk/python.md": "sdk/index.md" # sdk/python/api/index.html not supported by redirects plugin
         # Tutorial
         "tutorials/python/index.md": "tutorials/python/1-introduction.md"
         "tutorials/python/1_introduction.md": "tutorials/python/1-introduction.md"


### PR DESCRIPTION
Python-specific page was deleted in https://github.com/a2aproject/A2A/commit/f74fe490a86d127bb94257b63b0077d2fb4ee0ed

Fixes #1347