### PR TITLE
fix(spec): Update security schemes example

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -2115,8 +2115,9 @@ Clients verifying Agent Card signatures **MUST**:
   },
   "securitySchemes": {
     "google": {
-      "type": "openIdConnect",
-      "openIdConnectUrl": "https://accounts.google.com/.well-known/openid-configuration"
+      "openIdConnectSecurityScheme": {
+        "openIdConnectUrl": "https://accounts.google.com/.well-known/openid-configuration"
+      }
     }
   },
   "security": [{ "google": ["openid", "profile", "email"] }],


### PR DESCRIPTION
Update security scheme example to use the correct key for the security schemes instead of the `type` field.

This fixes #1355