### PR TITLE
docs(partners): Add MasOrange to partners list

### DIFF
--- a/docs/partners.md
+++ b/docs/partners.md
@@ -96,7 +96,7 @@ collaborate effectively with each other and with users.
 - [Lumeris](https://www.lumeris.com/)
 - [Lyzr.ai](https://lyzr.ai)
 - [Magyar Telekom](https://www.telekom.hu/)
-- [MasOrange](https://www.masorange.es)
+- [MasOrange](https://masorange.es/en/)
 - [Microsoft](https://www.microsoft.com/en-us/microsoft-cloud/blog/2025/05/07/empowering-multi-agent-apps-with-the-open-agent2agent-a2a-protocol/)
 - [MindsDB](https://mindsdb.com/blog/mindsdb-now-supports-the-agent2agent-(a2a)-protocol)
 - [McKinsey](https://www.mckinsey.com)

--- a/docs/partners.md
+++ b/docs/partners.md
@@ -96,6 +96,7 @@ collaborate effectively with each other and with users.
 - [Lumeris](https://www.lumeris.com/)
 - [Lyzr.ai](https://lyzr.ai)
 - [Magyar Telekom](https://www.telekom.hu/)
+- [MasOrange](https://www.masorange.es)
 - [Microsoft](https://www.microsoft.com/en-us/microsoft-cloud/blog/2025/05/07/empowering-multi-agent-apps-with-the-open-agent2agent-a2a-protocol/)
 - [MindsDB](https://mindsdb.com/blog/mindsdb-now-supports-the-agent2agent-(a2a)-protocol)
 - [McKinsey](https://www.mckinsey.com)


### PR DESCRIPTION
Hi A2A Team,
I’d like to submit [MasOrange](https://masorange.es/en/) to be added to the A2A partners list: https://a2a-protocol.org/latest/partners/

A2A integration: We are working with A2A as a core building block for agent discovery and agent-to-agent interoperability across our ecosystem. We also maintain ongoing discussions with Google on A2A-related topics, including Gemini Enterprise integrations and agentic cloud capabilities, providing them direct feedback. We are implementing A2A as the default protocol for exposing and connecting agentic systems within MasOrange, adapting its usage to our security and governance requirements, with future potential benefits for the OSS community.


Best regards,
Hugo Romero, AI Engineer at MasOrange