### PR TITLE
docs: Bring back Python SDK reference

### DIFF
--- a/docs/sdk/python/conf.py
+++ b/docs/sdk/python/conf.py
@@ -1,8 +1,8 @@
 # -- Project information -----------------------------------------------------
 
 project = 'a2a-sdk'
-copyright = '2025, Google LLC'
-author = 'Google LLC'
+copyright = '2026, The Linux Foundation'
+author = 'The Linux Foundation'
 
 # -- General configuration ---------------------------------------------------
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,7 +45,7 @@ nav:
       - Protocol Definition: definitions.md
   - SDK Reference:
       - sdk/index.md
-      - Python: sdk/python.md
+      - Python: sdk/python/api/index.html
   - Community: community.md
   - Partners: partners.md
   - Roadmap: roadmap.md
@@ -55,7 +55,7 @@ repo_name: a2aproject/A2A
 repo_url: https://github.com/a2aproject/A2A
 
 # Copyright
-copyright: Copyright 2025 The Linux Foundation. Licensed under the Apache License, Version 2.0.
+copyright: Copyright 2026 The Linux Foundation. Licensed under the Apache License, Version 2.0.
 
 # Custom CSS
 extra_css:
@@ -174,6 +174,6 @@ plugins:
         "tutorials/python/8-agent-capabilities.md": "tutorials/python/7-streaming-and-multiturn.md"
         "tutorials/python/9-ollama-agent.md": "tutorials/python/7-streaming-and-multiturn.md"
         "tutorials/python/10-next-steps.md": "tutorials/python/8-next-steps.md"
-        "sdk/python/": "sdk/python/api/index.html"
+        "sdk/python/index.md": "https://a2a-protocol.org/latest/sdk/python/api/index.html"
   - mike:
       canonical_version: latest


### PR DESCRIPTION
Currently [`SDK Reference > Python`](https://a2a-protocol.org/latest/sdk/python.md) link gives 404:

<img width="1138" height="308" alt="image" src="https://github.com/user-attachments/assets/2bd3bda0-0536-4450-8e82-5ec9ee5ce044" />

1. Fix the link to open [this](https://a2a-protocol.org/latest/sdk/python/api/index.html) instead. This was setup in #949 and is generated automatically from the latest docs. Looks like it was accidentally changed to `python.md` (the one not used ever before, it used to be `python/index.md`) in #1160.
2. Fix redirect to use absolute URL with `latest`. This is required due to https://github.com/mkdocs/mkdocs-redirects/issues/18, current way isn't going to work. `v0.3.0` tag of the website (the one you get after clicking `Latest Released Version` from [here](https://a2a-protocol.org/latest/specification/)) doesn't have the generated documentation either way, see [here](https://github.com/a2aproject/A2A/tree/gh-pages/v0.3.0/sdk/python).
3. Replace `Google LLC` with `The Linux Foundation` in the generated SDK reference.
4. Update copyright year in both places.

Tested via `mkdocs serve`.

Fixes #1347.