### PR TITLE
docs: use correct v1.0 method name "SendMessage" in life-of-a-task example

### DIFF
--- a/docs/topics/life-of-a-task.md
+++ b/docs/topics/life-of-a-task.md
@@ -141,7 +141,7 @@ The following example illustrates a typical task flow with a follow-up:
     {
       "jsonrpc": "2.0",
       "id": "req-001",
-      "method": "message.send",
+      "method": "SendMessage",
       "params": {
         "message": {
           "role": "user",


### PR DESCRIPTION
## Summary

The follow-up scenario example in \`docs/topics/life-of-a-task.md\` used \`"message.send"\` (dot notation) for the first request, while the second request in the same example correctly used \`"SendMessage"\` (v1.0 PascalCase). This made the file internally inconsistent and showed a method name that doesn't exist in any version of the protocol.

## Change

\`\`\`diff
- "method": "message.send",
+ "method": "SendMessage",
\`\`\`

**File:** \`docs/topics/life-of-a-task.md\`

## Related

- Closes #1493
- Related to #1367 (method name inconsistencies across documentation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)