### PR TITLE
build: use go 1.25 to work with latest buf

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
 
       - name: Install build tools
         run: |


### PR DESCRIPTION
https://github.com/a2aproject/A2A/actions/runs/22359664144 fails with

```
go: github.com/bufbuild/buf/cmd/buf@latest: github.com/bufbuild/buf@v1.66.0 requires go >= 1.25.6 (running go 1.24.12; GOTOOLCHAIN=local)
```

Long term docs.yml probably shouldn't use `@latest` to avoid such breakages in CI without code changes.

Re #1510 (adding `no-issue` as it's not `Fixes`)