### PR TITLE
docs: add AgentTrust to partners list

### DIFF
--- a/docs/partners.md
+++ b/docs/partners.md
@@ -11,7 +11,7 @@ collaborate effectively with each other and with users.
 - [Activeloop](https://www.activeloop.ai/)
 - [Adobe](https://www.adobe.com)
 - [AG2AI](https://ag2.ai)
-- [AgentTrust](https://agenttrust.ai)
+- [AgentTrust](https://agenttrust.ai/)
 - [AI21 Labs](https://www.ai21.com/)
 - [AI71](https://ai71.ai/)
 - [Aisera](https://aisera.com/)

--- a/docs/partners.md
+++ b/docs/partners.md
@@ -11,6 +11,7 @@ collaborate effectively with each other and with users.
 - [Activeloop](https://www.activeloop.ai/)
 - [Adobe](https://www.adobe.com)
 - [AG2AI](https://ag2.ai)
+- [AgentTrust](https://agenttrust.ai)
 - [AI21 Labs](https://www.ai21.com/)
 - [AI71](https://ai71.ai/)
 - [Aisera](https://aisera.com/)


### PR DESCRIPTION
This PR adds [AgentTrust](https://agenttrust.ai) to the partners list, alphabetically between AG2AI and AI21 Labs.

**About AgentTrust:**
AgentTrust is trust and identity infrastructure for agentic collaboration. We provide hosted A2A endpoints with Agent Card discovery, Ed25519 message signing, human-in-the-loop escalation, and prompt injection detection.

**What we've built:**
- Hosted A2A endpoints — agents get a public A2A identity at `/a2a/{slug}` without running a server
- Standard Agent Card served at `/.well-known/agent.json` per agent
- Direct A2A JSON-RPC ingress (`tasks/send`) with allowlist, InjectionGuard, and HITL rules
- Ed25519 message signing — cryptographic identity verification between agents
- Negotiation lifecycle extending A2A task states via metadata extensions (`propose_complete`, `disputed`, `rejected`)
- MCP server with 13 tools — [npm](https://www.npmjs.com/package/@agenttrust/mcp-server) | [GitHub](https://github.com/agenttrust/mcp-server)
- Webhook delivery with HMAC-SHA256 signatures

**Links:**
- Website: https://agenttrust.ai
- MCP Server: https://github.com/agenttrust/mcp-server
- npm: https://www.npmjs.com/package/@agenttrust/mcp-server

Built on Google's A2A protocol. We fill the identity and trust gap — A2A defines how agents talk, AgentTrust helps them prove who they are.