### PR TITLE
docs(spec): clarify contextId optional generation and client side semantics

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -624,10 +624,11 @@ The A2A protocol supports several patterns for multi-turn interactions. Agents t
 **Context Continuity:**
 
 - [`Task`](#411-task) objects maintain conversation context through the `contextId` field
-- Clients **MAY** include a `contextId` in any [`Message`](#414-message) to associate it with an existing context or to indicate continuation of a previous interaction
+- Clients **MAY** include the `contextId` in subsequent messages to indicate continuation of a previous interaction
 - Clients **MAY** use `taskId` (with or without `contextId`) to continue or refine a specific task
-- Clients **MAY** use `contextId` without `taskId` to start a new task within an existing conversation context
+- Clients **MAY** use `contextId` without `taskId` to start a new task within an existing or non-existing conversation context provided validations pass
 - Agents **MUST** infer `contextId` from the task if only `taskId` is provided
+- Agents **MUST** reject messages containing mismatching `contextId` and `taskId` (i.e., the provided `contextId` is different from the `contextId` of the referenced [`Task`](#411-task)).
 
 **Input Required State:**
 


### PR DESCRIPTION
Clients MAY provide a contextId in a Message to associate it with an existing context. Server MUST generate contextId when creating a Task but MAY omit it when responding with a Message only (no task created).

Keeps Task.context_id as REQUIRED in [a2a.proto](https://github.com/a2aproject/A2A/blob/d1ed0da587d2d634ba0b81a40d082cee0850b81b/specification/a2a.proto) — no breaking change.

Fixes #1581