### PR TITLE
fix(spec): Remove config from binding.

### DIFF
--- a/specification/a2a.proto
+++ b/specification/a2a.proto
@@ -90,10 +90,10 @@ service A2AService {
   rpc CreateTaskPushNotificationConfig(TaskPushNotificationConfig) returns (TaskPushNotificationConfig) {
     option (google.api.http) = {
       post: "/tasks/{task_id=*}/pushNotificationConfigs"
-      body: "config"
+      body: "*"
       additional_bindings: {
         post: "/{tenant}/tasks/{task_id=*}/pushNotificationConfigs"
-        body: "config"
+        body: "*"
       }
     };
     option (google.api.method_signature) = "task_id,config";


### PR DESCRIPTION
Fix error caused by #1500:

× Failed to build `a2a-sdk @ file:///home/runner/work/a2a-python/a2a-python`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `hatchling.build.build_editable` failed (exit status: 1)

      [stderr]
      Failure: failed_precondition: plugin
      "buf.build/grpc-ecosystem/openapiv2:v2.28.0" failed: no field "config"
      found in TaskPushNotificationConfig