### PR TITLE
feat(extensions): add AIAR identity extension (v0 MVP)

### DIFF
--- a/docs/extensions/aiar-identity-v0.md
+++ b/docs/extensions/aiar-identity-v0.md
@@ -1,0 +1,517 @@
+# Agent Identity and Accountability Reporting (AIAR) Extension — v0
+
+**Extension URI:** `https://github.com/a2aproject/A2A/extensions/aiar.identity/v0`
+
+**Status:** Draft (v0 — MVP)
+
+**Authors:** A2A Community Contributors
+
+---
+
+## Abstract
+
+Discovery is not identity. Runtime authentication is not ownership.
+
+The A2A protocol enables agents to discover one another via Agent Cards and
+communicate through well-defined message flows. However, the base protocol does
+not provide a mechanism for a client to **verify** that a given Agent Card
+or runtime endpoint is bound to a **verifiable issuer identity**.
+
+The Agent Identity and Accountability Reporting (AIAR) extension addresses this
+gap by introducing:
+
+1. **Verifiable identity binding** in Agent Cards via JWS signatures tied to a
+    declared issuer.
+2. **Runtime proof-of-possession** so clients can confirm the agent endpoint
+    controls the signing key.
+3. **Optional RPC methods** for programmatic retrieval of identity proofs and
+    issuer metadata.
+
+This extension is fully opt-in, additive, and backwards-compatible. It does
+**not** attempt to solve global governance, reputation, or revocation
+infrastructure. Instead, it provides the cryptographic primitives and
+metadata structure that higher-level trust frameworks can build upon.
+
+## Motivation
+
+| Scenario | Gap without AIAR |
+| :--- | :--- |
+| Client discovers an Agent Card at `/.well-known/agent-card.json` | No proof the card was published by the claimed organization |
+| Client sends sensitive data to an agent endpoint | No proof the endpoint is operated by the Agent Card's issuer |
+| Agent Card is served from a CDN or registry | No tamper-evidence; card could be modified in transit |
+| Multiple agents claim to be from "Acme Corp" | No way to distinguish legitimate agents from imposters |
+
+## Terminology
+
+| Term | Definition |
+| :--- | :--- |
+| **Issuer** | The organization or entity that publishes and vouches for an agent. Identified by a URI (e.g., DID, HTTPS URL). |
+| **Subject Agent** | The agent whose identity is being asserted by the issuer. |
+| **Agent Card** | The self-describing manifest for an agent, as defined by the A2A specification. |
+| **Proof Bundle** | A collection of cryptographic proofs (JWS, timestamps, optional attestations) that bind an agent to its issuer. |
+| **Trusted Issuer Set** | A client-defined policy listing issuers the client is willing to trust. This is NOT defined by this extension; it is a client implementation concern. |
+| **Key ID (kid)** | A unique identifier for the signing key, as used in JWS headers (RFC 7515). |
+| **JCS** | JSON Canonicalization Scheme (RFC 8785), used to produce a deterministic representation of JSON objects for signing. |
+
+## Extension Type
+
+This extension is a combination of:
+
+- **Data-only**: Adds identity metadata to Agent Card `params`.
+- **Profile**: Adds structured request/response data in message `metadata`.
+- **Method (Extended Skills)**: Defines optional RPC methods (`aiar.*`).
+
+## Activation
+
+### Declaration
+
+Agents that support this extension declare it in their Agent Card under
+`capabilities.extensions`:
+
+```json
+{
+    "uri": "https://github.com/a2aproject/A2A/extensions/aiar.identity/v0",
+    "description": "Verifiable agent identity and accountability reporting",
+    "required": false,
+    "params": {
+        "issuer": "https://example.com",
+        "kid": "example-key-2025-01",
+        "signedFields": "card",
+        "jws": {
+            "protected": "eyJhbGciOiJFUzI1NiIsImtpZCI6ImV4YW1wbGUta2V5LTIwMjUtMDEifQ",
+            "signature": "MEUCIQC...base64url..."
+        }
+    }
+}
+```
+
+### Client Opt-In
+
+Clients opt in to this extension by including the extension URI in the
+`A2A-Extensions` HTTP header (or gRPC metadata) when making requests:
+
+```http
+POST /message:send HTTP/1.1
+Host: agent.example.com
+Content-Type: application/json
+A2A-Extensions: https://github.com/a2aproject/A2A/extensions/aiar.identity/v0
+```
+
+### Agent Response
+
+When the extension is successfully activated, the agent includes the extension
+URI in the response `A2A-Extensions` header:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+A2A-Extensions: https://github.com/a2aproject/A2A/extensions/aiar.identity/v0
+```
+
+If the agent does not support this extension, it ignores the activation request
+and omits the URI from the response header.
+
+## Agent Card Identity Parameters
+
+When an agent declares support for this extension, the `params` field of the
+`AgentExtension` object contains the following fields:
+
+| Field | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `issuer` | string | Yes | URI identifying the issuing organization (HTTPS URL or DID). |
+| `kid` | string | Yes | Key ID referencing the signing key. The key material SHOULD be resolvable via the issuer's JWKS endpoint (`{issuer}/.well-known/jwks.json`) or DID document. |
+| `signedFields` | string | Yes | What is signed. Value MUST be `"card"` (the entire Agent Card minus the AIAR extension's `jws` field). |
+| `jws` | object | Yes | JWS JSON Serialization (RFC 7515 §7.2) containing the signature over the canonical Agent Card. See [Signing Target](#signing-target). |
+| `jws.protected` | string | Yes | Base64url-encoded protected JWS header. MUST include `alg` and `kid`. |
+| `jws.signature` | string | Yes | Base64url-encoded signature value. |
+| `jws.header` | object | No | Unprotected JWS header values. |
+| `attestations` | array | No | Optional array of third-party attestation objects. See [Attestations](#attestations). |
+
+### Signing Target
+
+The signing target is a **canonical JSON representation** of the Agent Card,
+constructed as follows:
+
+1. Start with the complete Agent Card JSON object.
+2. Remove the `jws` field from the AIAR extension's `params` object (i.e.,
+    remove `capabilities.extensions[aiar].params.jws`). All other fields,
+    including `params.issuer`, `params.kid`, and `params.signedFields`,
+    remain in the signing input.
+3. Apply [RFC 8785 (JCS)](https://www.rfc-editor.org/rfc/rfc8785) canonicalization
+    to produce a deterministic UTF-8 byte string.
+4. The resulting byte string is the JWS payload. The JWS MAY use either
+    attached or detached payload (RFC 7515 Appendix F). If detached, the
+    verifier reconstructs the payload using the same canonicalization steps.
+
+**Recommended algorithms** (in order of preference):
+
+- `ES256` (ECDSA using P-256 and SHA-256)
+- `EdDSA` (Ed25519)
+- `RS256` (RSASSA-PKCS1-v1_5 using SHA-256) — for legacy compatibility only
+
+### Attestations
+
+The optional `attestations` array allows issuers to include third-party
+credentials that vouch for the agent's identity. Each attestation object has:
+
+| Field | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `type` | string | Yes | Attestation type. Values: `"uri"` (reference) or `"vc"` (embedded Verifiable Credential). |
+| `value` | string | Yes | For `"uri"`: a URL to the attestation document. For `"vc"`: an embedded W3C Verifiable Credential (JWT or JSON-LD compact form). |
+| `description` | string | No | Human-readable description of the attestation. |
+
+### Verification Steps (Agent Card)
+
+A client verifying an Agent Card's identity binding MUST perform these steps:
+
+1. **Extract** the AIAR extension from `capabilities.extensions[]` by matching
+    the extension URI.
+2. **Decode** the `jws.protected` header and extract `alg` and `kid`.
+3. **Resolve** the signing key using the `kid`:
+    - If `issuer` is an HTTPS URL: fetch `{issuer}/.well-known/jwks.json` and
+        find the key matching `kid`.
+    - If `issuer` is a DID: resolve the DID document and find the
+        verification method matching `kid`.
+4. **Reconstruct** the signing target by removing `params.jws` from the AIAR
+    extension entry and applying JCS canonicalization to the resulting Agent Card.
+5. **Verify** the JWS signature using the resolved key and reconstructed payload.
+6. **Check issuer trust**: verify that `issuer` is in the client's Trusted
+    Issuer Set (a client policy decision).
+7. **Optionally validate** any `attestations` entries.
+
+## Message-Level Identity Requests and Proofs
+
+### Request Extension Data
+
+When a client wants to request identity proof at the message level, it includes
+an identity request in the `SendMessageRequest.metadata` map, keyed by the
+extension URI with a `/request` suffix:
+
+**Metadata key:** `https://github.com/a2aproject/A2A/extensions/aiar.identity/v0/request`
+
+| Field | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `minAssurance` | string | Yes | Minimum assurance level required. Values: `"self-signed"`, `"org-signed"`, `"third-party-signed"`. |
+| `acceptableIssuers` | array of strings | No | List of issuer URIs the client will accept. If omitted, the client accepts any issuer in its local Trusted Issuer Set. |
+| `requireFreshnessSeconds` | integer | No | Maximum age (in seconds) of the proof bundle. If omitted, the client accepts any valid proof. |
+
+**Assurance levels:**
+
+| Level | Meaning |
+| :--- | :--- |
+| `self-signed` | The agent's key is self-asserted; no organizational binding required. |
+| `org-signed` | The signing key is bound to an organizational issuer identity. |
+| `third-party-signed` | The identity includes at least one third-party attestation. |
+
+**Example request:**
+
+```http
+POST /message:send HTTP/1.1
+Host: agent.example.com
+Content-Type: application/json
+A2A-Extensions: https://github.com/a2aproject/A2A/extensions/aiar.identity/v0
+
+{
+    "jsonrpc": "2.0",
+    "method": "SendMessage",
+    "id": "req-42",
+    "params": {
+        "message": {
+            "messageId": "msg-001",
+            "role": "ROLE_USER",
+            "parts": [{"text": "Process this invoice."}],
+            "extensions": [
+                "https://github.com/a2aproject/A2A/extensions/aiar.identity/v0"
+            ]
+        },
+        "metadata": {
+            "https://github.com/a2aproject/A2A/extensions/aiar.identity/v0/request": {
+                "minAssurance": "org-signed",
+                "requireFreshnessSeconds": 300
+            }
+        }
+    }
+}
+```
+
+### Response Proof Bundle
+
+When the extension is active and the agent supports the requested assurance
+level, the agent includes a proof bundle in the response `Task.metadata` (or
+`Message.metadata` for direct message responses), keyed by the extension URI
+with a `/proof_bundle` suffix:
+
+**Metadata key:** `https://github.com/a2aproject/A2A/extensions/aiar.identity/v0/proof_bundle`
+
+| Field | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `cardDigest` | string | Yes | Base64url-encoded SHA-256 hash of the JCS-canonicalized Agent Card (same canonical form used for the Agent Card signature). |
+| `issuer` | string | Yes | The issuer URI (must match the Agent Card's AIAR `params.issuer`). |
+| `kid` | string | Yes | The key ID used for signing this proof. |
+| `proofOfPossession` | object | Yes | A JWS proving the agent currently controls the signing key. See below. |
+| `issuedAt` | string | Yes | ISO 8601 timestamp of when this proof was generated. |
+| `expiresAt` | string | Yes | ISO 8601 timestamp of when this proof expires. |
+| `attestations` | array | No | Optional attestations (same schema as Agent Card attestations). |
+
+#### Proof of Possession
+
+The `proofOfPossession` field is a JWS (compact or JSON serialization) whose
+payload is a JSON object containing:
+
+```json
+{
+    "iss": "https://example.com",
+    "sub": "https://agent.example.com/.well-known/agent-card.json",
+    "cardDigest": "sha256:base64url-encoded-hash",
+    "iat": 1735689600,
+    "exp": 1735689900,
+    "nonce": "client-provided-or-server-generated"
+}
+```
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `iss` | string | The issuer URI. |
+| `sub` | string | The Agent Card URL or agent identifier. |
+| `cardDigest` | string | SHA-256 digest of the canonical Agent Card, prefixed with `sha256:`. |
+| `iat` | integer | Issued-at Unix timestamp. |
+| `exp` | integer | Expiration Unix timestamp. |
+| `nonce` | string | A nonce for replay prevention. Server-generated if not provided by client. |
+
+**Example response:**
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": "req-42",
+    "result": {
+        "id": "task-101",
+        "contextId": "ctx-001",
+        "status": {
+            "state": "TASK_STATE_COMPLETED",
+            "message": {
+                "messageId": "msg-002",
+                "role": "ROLE_AGENT",
+                "parts": [{"text": "Invoice processed successfully."}],
+                "extensions": [
+                    "https://github.com/a2aproject/A2A/extensions/aiar.identity/v0"
+                ]
+            }
+        },
+        "metadata": {
+            "https://github.com/a2aproject/A2A/extensions/aiar.identity/v0/proof_bundle": {
+                "cardDigest": "sha256:abc123def456...",
+                "issuer": "https://example.com",
+                "kid": "example-key-2025-01",
+                "proofOfPossession": {
+                    "protected": "eyJhbGciOiJFUzI1NiIsImtpZCI6ImV4YW1wbGUta2V5LTIwMjUtMDEifQ",
+                    "payload": "eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIi...",
+                    "signature": "MEUCIQD...base64url..."
+                },
+                "issuedAt": "2025-12-01T00:00:00Z",
+                "expiresAt": "2025-12-01T00:05:00Z"
+            }
+        }
+    }
+}
+```
+
+## Optional RPC Methods
+
+This extension defines the following optional RPC methods. Agents MAY implement
+them. Clients MUST handle a "method not found" error gracefully if the agent
+does not support them.
+
+These methods follow the JSON-RPC 2.0 calling convention used by A2A.
+
+### `aiar.getProofBundle`
+
+Returns a fresh proof bundle for the agent's identity.
+
+**Request:**
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "aiar.getProofBundle",
+    "id": "rpc-1",
+    "params": {
+        "includeAttestations": true
+    }
+}
+```
+
+| Parameter | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `includeAttestations` | boolean | No | If `true`, include attestations in the response. Defaults to `false`. |
+
+**Response:**
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": "rpc-1",
+    "result": {
+        "cardDigest": "sha256:abc123def456...",
+        "issuer": "https://example.com",
+        "kid": "example-key-2025-01",
+        "proofOfPossession": {
+            "protected": "eyJhbGciOiJFUzI1NiJ9",
+            "payload": "eyJpc3MiOi...",
+            "signature": "MEUCIQD..."
+        },
+        "issuedAt": "2025-12-01T00:00:00Z",
+        "expiresAt": "2025-12-01T00:05:00Z",
+        "attestations": [
+            {
+                "type": "uri",
+                "value": "https://trust-registry.example.org/attestations/acme-corp",
+                "description": "Acme Corp verified agent operator"
+            }
+        ]
+    }
+}
+```
+
+### `aiar.getIssuer`
+
+Returns metadata about the agent's issuer.
+
+**Request:**
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "aiar.getIssuer",
+    "id": "rpc-2",
+    "params": {}
+}
+```
+
+**Response:**
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": "rpc-2",
+    "result": {
+        "issuer": "https://example.com",
+        "issuerUrl": "https://example.com/about",
+        "policyUrl": "https://example.com/agent-policy",
+        "contact": "security@example.com"
+    }
+}
+```
+
+| Field | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `issuer` | string | Yes | The issuer URI (same as in Agent Card). |
+| `issuerUrl` | string | No | URL with human-readable information about the issuer. |
+| `policyUrl` | string | No | URL to the issuer's agent operation policy. |
+| `contact` | string | No | Contact information for security or identity inquiries. |
+
+### `aiar.rotateKeys` (Deferred)
+
+Key rotation is an important operational concern but is deferred from the v0
+MVP. Future versions of this extension MAY define an `aiar.rotateKeys` method
+that allows agents to signal key rotation events to subscribed clients. For v0,
+key rotation is handled out-of-band by updating the Agent Card and the issuer's
+JWKS endpoint.
+
+## Relationship to Agent Card `signatures` Field
+
+The A2A protocol defines a top-level `signatures` field on the `AgentCard`
+message (type `AgentCardSignature`). This field provides a general-purpose
+mechanism for JWS signatures over Agent Cards.
+
+The AIAR extension **complements** rather than replaces `signatures`:
+
+- `AgentCard.signatures` provides raw JWS mechanics without identity semantics.
+- AIAR adds **issuer binding**, **key resolution conventions**, **runtime
+    proof-of-possession**, and **structured attestations**.
+
+Agents MAY use both: `signatures` for transport-level integrity and the AIAR
+extension for identity verification. The AIAR extension's `params.jws` follows
+the same JWS JSON Serialization format as `AgentCardSignature`.
+
+## Versioning Policy
+
+- The extension URI includes a version segment (`/v0`).
+- Non-breaking additions (new optional fields in `params`, new optional RPC
+    methods) MAY be made within the same version.
+- Breaking changes (removing fields, changing semantics of existing fields,
+    changing the signing target) MUST use a new URI (e.g., `.../v1`).
+- Agents MUST NOT fall back to a different version if the requested version is
+    not supported.
+
+## Security Considerations
+
+### Sybil Resistance
+
+This extension does not provide global Sybil resistance. Any entity can create
+a signing key and self-sign an Agent Card. The Trusted Issuer Set is a **client
+policy decision** — clients MUST maintain their own list of trusted issuers and
+MUST NOT trust an agent solely because it presents a valid AIAR signature.
+
+### Replay Prevention
+
+The proof-of-possession mechanism includes `iat`, `exp`, and `nonce` fields to
+mitigate replay attacks. Clients SHOULD:
+
+- Reject proofs where `exp` is in the past.
+- Reject proofs where `iat` is too far in the past (per
+    `requireFreshnessSeconds`).
+- Use unique nonces when possible.
+
+### Key Compromise and Rotation
+
+If a signing key is compromised:
+
+1. The issuer MUST remove the compromised key from their JWKS endpoint (or DID
+    document).
+2. The issuer MUST update all affected Agent Cards with a new `kid` and
+    re-sign.
+3. Clients that cache JWKS responses SHOULD implement a maximum cache TTL and
+    re-fetch keys periodically.
+
+This extension does not define a real-time revocation mechanism. Implementors
+requiring immediate revocation should consider supplementing with short-lived
+proof bundles (small `expiresAt` windows) and frequent JWKS polling.
+
+### Phishing and Impersonation
+
+A valid JWS signature alone does not prevent impersonation — the client MUST
+also verify that the `issuer` is in its Trusted Issuer Set. A signature from
+an untrusted issuer provides integrity but not trustworthiness.
+
+### Privacy
+
+This extension is designed to assert **organizational** identity, not personal
+identity. The `issuer` field identifies an organization, not an individual.
+Implementations SHOULD NOT include personally identifiable information in
+Agent Card `params` or proof bundles. The `contact` field in `aiar.getIssuer`
+is intended for organizational security contacts, not personal data.
+
+## Compatibility
+
+- **Backwards-compatible**: Agents that do not support this extension simply
+    omit it from their `capabilities.extensions`. Existing clients and agents
+    are unaffected.
+- **Core schema unchanged**: All AIAR data is placed in existing extension
+    points (`AgentExtension.params`, `Message.metadata`, `Task.metadata`).
+    No core protobuf messages are modified.
+- **Graceful degradation**: If a client requests AIAR but the agent does not
+    support it, the agent ignores the `A2A-Extensions` header and proceeds
+    normally. The client observes the absence of the extension URI in the
+    response header.
+
+## Out of Scope (v0)
+
+The following are explicitly **not** addressed by this MVP:
+
+- Global trust registries or federated identity governance.
+- Certificate revocation lists (CRLs) or OCSP-style revocation checking.
+- Reputation scoring or behavioral trust metrics.
+- End-to-end message encryption (orthogonal concern).
+- Agent-to-agent mutual authentication (may be addressed in a future version).
+- Automated key rotation notification (`aiar.rotateKeys` is deferred).

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1134,6 +1134,82 @@ Artifacts can include extension data to provide strongly typed context or metada
 }
 ```
 
+*Example: Agent Card with AIAR identity extension ([spec](../extensions/aiar-identity-v0.md)):*
+
+```json
+{
+  "name": "Invoice Processing Agent",
+  "description": "Processes invoices with verifiable organizational identity",
+  "supportedInterfaces": [
+    {
+      "url": "https://agent.example.com/a2a/v1",
+      "protocolBinding": "JSONRPC",
+      "protocolVersion": "0.3"
+    }
+  ],
+  "capabilities": {
+    "extensions": [
+      {
+        "uri": "https://github.com/a2aproject/A2A/extensions/aiar.identity/v0",
+        "description": "Verifiable agent identity and accountability reporting",
+        "required": false,
+        "params": {
+          "issuer": "https://example.com",
+          "kid": "example-key-2025-01",
+          "signedFields": "card",
+          "jws": {
+            "protected": "eyJhbGciOiJFUzI1NiIsImtpZCI6ImV4YW1wbGUta2V5LTIwMjUtMDEifQ",
+            "signature": "MEUCIQC...base64url..."
+          }
+        }
+      }
+    ]
+  },
+  "version": "1.0.0",
+  "defaultInputModes": ["text/plain"],
+  "defaultOutputModes": ["text/plain"],
+  "skills": [
+    {
+      "id": "invoice-processing",
+      "name": "Invoice Processor",
+      "description": "Processes and validates invoices",
+      "tags": ["finance", "invoices"]
+    }
+  ]
+}
+```
+
+*Example: Client requesting identity proof via message metadata:*
+
+```http
+POST /message:send HTTP/1.1
+Host: agent.example.com
+Content-Type: application/json
+A2A-Extensions: https://github.com/a2aproject/A2A/extensions/aiar.identity/v0
+
+{
+  "jsonrpc": "2.0",
+  "method": "SendMessage",
+  "id": "req-42",
+  "params": {
+    "message": {
+      "messageId": "msg-001",
+      "role": "ROLE_USER",
+      "parts": [{"text": "Process this invoice."}],
+      "extensions": [
+        "https://github.com/a2aproject/A2A/extensions/aiar.identity/v0"
+      ]
+    },
+    "metadata": {
+      "https://github.com/a2aproject/A2A/extensions/aiar.identity/v0/request": {
+        "minAssurance": "org-signed",
+        "requireFreshnessSeconds": 300
+      }
+    }
+  }
+}
+```
+
 #### 4.6.3. Extension Versioning and Compatibility
 
 Extensions **SHOULD** include version information in their URI identifier. This allows clients and agents to negotiate compatible versions of extensions during interactions. A new URI **MUST** be created for breaking changes to an extension.

--- a/docs/topics/extensions.md
+++ b/docs/topics/extensions.md
@@ -46,6 +46,7 @@ However, some foreseeable applications include:
 
 | Extension | Description |
 | :-------- | :------------ |
+| [Agent Identity and Accountability Reporting (AIAR)](../extensions/aiar-identity-v0.md) | Provides verifiable identity binding for Agent Cards and runtime proof-of-possession for agent endpoints (v0). |
 | [Secure Passport Extension](https://github.com/a2aproject/a2a-samples/tree/main/extensions/secure-passport) | Adds a trusted, contextual layer for immediate personalization and reduced overhead (v1). |
 | [Hello World or Timestamp Extension](https://github.com/a2aproject/a2a-samples/tree/main/extensions/timestamp) | A simple extension demonstrating how to augment base A2A types by adding timestamps to the `metadata` field of `Message` and `Artifact` objects (v1). |
 | [Traceability Extension](https://github.com/a2aproject/a2a-samples/tree/main/samples/python/extensions/traceability) | Explore the Python implementation and basic usage of the Traceability Extension (v1). |

--- a/examples/aiar-identity/README.md
+++ b/examples/aiar-identity/README.md
@@ -1,0 +1,100 @@
+# AIAR Identity Extension — Example Payloads
+
+This folder contains example JSON payloads for the
+[Agent Identity and Accountability Reporting (AIAR) extension](../../docs/extensions/aiar-identity-v0.md).
+
+**Extension URI:** `https://github.com/a2aproject/A2A/extensions/aiar.identity/v0`
+
+## Files
+
+| File | Description |
+| :--- | :--- |
+| `agent-card.json` | A standard Agent Card without the AIAR extension |
+| `agent-card.signed.json` | An Agent Card with the AIAR extension declared, including issuer metadata and JWS signature |
+| `message.request.json` | A `SendMessage` request with AIAR identity requirements in metadata |
+| `message.response.json` | A task response including an AIAR proof bundle in metadata |
+| `proof-bundle.json` | A standalone proof bundle object (as returned by `aiar.getProofBundle`) |
+
+## Signature Values
+
+The JWS `protected`, `payload`, and `signature` values in these examples are
+**illustrative placeholders**. In a real deployment:
+
+- `protected` is a base64url-encoded JSON object containing `{"alg":"ES256","kid":"example-key-2025-01"}`.
+- `payload` is the JCS-canonicalized Agent Card (for card signatures) or a proof-of-possession claims object (for runtime proofs).
+- `signature` is the actual ECDSA/EdDSA/RSA signature output.
+
+## How to Verify an Agent Card Signature
+
+1. **Fetch the Agent Card** from `/.well-known/agent-card.json`.
+
+2. **Locate the AIAR extension** in `capabilities.extensions[]` by matching the
+    URI `https://github.com/a2aproject/A2A/extensions/aiar.identity/v0`.
+
+3. **Extract identity fields** from `params`:
+    - `issuer` — the organizational identity URI
+    - `kid` — the key identifier
+    - `jws` — the JWS signature object
+
+4. **Resolve the signing key**:
+    - If `issuer` is an HTTPS URL: GET `{issuer}/.well-known/jwks.json` and
+        find the key where `kid` matches.
+    - If `issuer` is a DID: resolve the DID document and find the verification
+        method matching `kid`.
+
+5. **Reconstruct the signing input**:
+    - Copy the Agent Card JSON.
+    - Remove the `jws` field from the AIAR extension's `params`.
+    - Apply RFC 8785 (JCS) canonicalization to produce a deterministic byte string.
+
+6. **Verify the JWS**:
+    - Decode the `protected` header to get `alg`.
+    - Verify the signature over the canonicalized payload using the resolved key.
+
+7. **Check issuer trust**:
+    - Verify that `issuer` is in your Trusted Issuer Set (a client policy decision).
+
+## How to Verify a Runtime Proof Bundle
+
+1. **Extract the proof bundle** from the response `metadata` under the key
+    `https://github.com/a2aproject/A2A/extensions/aiar.identity/v0/proof_bundle`.
+
+2. **Check timestamps**:
+    - `issuedAt` should not be in the future.
+    - `expiresAt` should not be in the past.
+    - If `requireFreshnessSeconds` was specified in the request, verify that
+        `issuedAt` is within the freshness window.
+
+3. **Verify `cardDigest`**:
+    - Fetch the Agent Card and compute its JCS-canonicalized SHA-256 hash.
+    - Compare with `cardDigest` (after removing the `sha256:` prefix and
+        base64url-decoding).
+
+4. **Verify `proofOfPossession`**:
+    - Decode the JWS payload to extract claims (`iss`, `sub`, `cardDigest`,
+        `iat`, `exp`, `nonce`).
+    - Verify the JWS signature using the key resolved from `kid` / `issuer`.
+    - Verify that `iss` matches the `issuer` in the proof bundle.
+    - Verify that `cardDigest` in the claims matches the top-level `cardDigest`.
+
+5. **Validate attestations** (optional):
+    - For `"type": "uri"` attestations, fetch and validate the linked document.
+    - For `"type": "vc"` attestations, verify the Verifiable Credential.
+
+## Trusted Issuer Set (Client Policy)
+
+The AIAR extension does not prescribe a global trust model. Each client
+maintains its own Trusted Issuer Set. A simple implementation might be a
+static allowlist:
+
+```json
+{
+  "trustedIssuers": [
+    "https://example.com",
+    "https://trusted-partner.org"
+  ]
+}
+```
+
+More sophisticated implementations might integrate with organizational PKI,
+trust registries, or Verifiable Credential ecosystems.

--- a/examples/aiar-identity/agent-card.json
+++ b/examples/aiar-identity/agent-card.json
@@ -1,0 +1,31 @@
+{
+  "name": "Invoice Processing Agent",
+  "description": "Processes and validates invoices with AI-powered extraction",
+  "supportedInterfaces": [
+    {
+      "url": "https://agent.example.com/a2a/v1",
+      "protocolBinding": "JSONRPC",
+      "protocolVersion": "0.3"
+    }
+  ],
+  "provider": {
+    "organization": "Example Corp",
+    "url": "https://example.com"
+  },
+  "version": "1.0.0",
+  "capabilities": {
+    "streaming": false,
+    "pushNotifications": false,
+    "extensions": []
+  },
+  "defaultInputModes": ["text/plain", "application/json"],
+  "defaultOutputModes": ["text/plain", "application/json"],
+  "skills": [
+    {
+      "id": "invoice-processing",
+      "name": "Invoice Processor",
+      "description": "Extracts and validates invoice data",
+      "tags": ["finance", "invoices", "extraction"]
+    }
+  ]
+}

--- a/examples/aiar-identity/agent-card.signed.json
+++ b/examples/aiar-identity/agent-card.signed.json
@@ -1,0 +1,46 @@
+{
+  "name": "Invoice Processing Agent",
+  "description": "Processes and validates invoices with AI-powered extraction",
+  "supportedInterfaces": [
+    {
+      "url": "https://agent.example.com/a2a/v1",
+      "protocolBinding": "JSONRPC",
+      "protocolVersion": "0.3"
+    }
+  ],
+  "provider": {
+    "organization": "Example Corp",
+    "url": "https://example.com"
+  },
+  "version": "1.0.0",
+  "capabilities": {
+    "streaming": false,
+    "pushNotifications": false,
+    "extensions": [
+      {
+        "uri": "https://github.com/a2aproject/A2A/extensions/aiar.identity/v0",
+        "description": "Verifiable agent identity and accountability reporting",
+        "required": false,
+        "params": {
+          "issuer": "https://example.com",
+          "kid": "example-key-2025-01",
+          "signedFields": "card",
+          "jws": {
+            "protected": "eyJhbGciOiJFUzI1NiIsImtpZCI6ImV4YW1wbGUta2V5LTIwMjUtMDEiLCJ0eXAiOiJhZ2VudC1jYXJkK2p3cyJ9",
+            "signature": "MEUCIQDExample_Base64url_Signature_Value_Here_For_Illustration_OnlyIgExample"
+          }
+        }
+      }
+    ]
+  },
+  "defaultInputModes": ["text/plain", "application/json"],
+  "defaultOutputModes": ["text/plain", "application/json"],
+  "skills": [
+    {
+      "id": "invoice-processing",
+      "name": "Invoice Processor",
+      "description": "Extracts and validates invoice data",
+      "tags": ["finance", "invoices", "extraction"]
+    }
+  ]
+}

--- a/examples/aiar-identity/message.request.json
+++ b/examples/aiar-identity/message.request.json
@@ -1,0 +1,29 @@
+{
+  "jsonrpc": "2.0",
+  "method": "SendMessage",
+  "id": "req-42",
+  "params": {
+    "message": {
+      "messageId": "msg-001",
+      "role": "ROLE_USER",
+      "parts": [
+        {
+          "text": "Process this invoice."
+        }
+      ],
+      "extensions": [
+        "https://github.com/a2aproject/A2A/extensions/aiar.identity/v0"
+      ]
+    },
+    "metadata": {
+      "https://github.com/a2aproject/A2A/extensions/aiar.identity/v0/request": {
+        "minAssurance": "org-signed",
+        "acceptableIssuers": [
+          "https://example.com",
+          "https://trusted-partner.org"
+        ],
+        "requireFreshnessSeconds": 300
+      }
+    }
+  }
+}

--- a/examples/aiar-identity/message.response.json
+++ b/examples/aiar-identity/message.response.json
@@ -1,0 +1,37 @@
+{
+  "jsonrpc": "2.0",
+  "id": "req-42",
+  "result": {
+    "id": "task-101",
+    "contextId": "ctx-001",
+    "status": {
+      "state": "TASK_STATE_COMPLETED",
+      "message": {
+        "messageId": "msg-002",
+        "role": "ROLE_AGENT",
+        "parts": [
+          {
+            "text": "Invoice processed successfully. Total: $1,250.00, Vendor: Acme Supplies."
+          }
+        ],
+        "extensions": [
+          "https://github.com/a2aproject/A2A/extensions/aiar.identity/v0"
+        ]
+      }
+    },
+    "metadata": {
+      "https://github.com/a2aproject/A2A/extensions/aiar.identity/v0/proof_bundle": {
+        "cardDigest": "sha256:ZXhhbXBsZV9kaWdlc3RfdmFsdWVfaGVyZQ",
+        "issuer": "https://example.com",
+        "kid": "example-key-2025-01",
+        "proofOfPossession": {
+          "protected": "eyJhbGciOiJFUzI1NiIsImtpZCI6ImV4YW1wbGUta2V5LTIwMjUtMDEiLCJ0eXAiOiJwb3Aram3rIn0",
+          "payload": "eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwic3ViIjoiaHR0cHM6Ly9hZ2VudC5leGFtcGxlLmNvbS8ud2VsbC1rbm93bi9hZ2VudC1jYXJkLmpzb24iLCJjYXJkRGlnZXN0Ijoic2hhMjU2OlpleGhiWEJzWlY5a2FXZGxjM1JmZG1Gc2RXVmZhR1Z5WlEiLCJpYXQiOjE3MzU2ODk2MDAsImV4cCI6MTczNTY4OTkwMCwibm9uY2UiOiJhYmNkMTIzNCJ9",
+          "signature": "MEUCIQDExample_PoP_Signature_Base64url_For_Illustration_OnlyIgExample_Value"
+        },
+        "issuedAt": "2025-12-01T00:00:00Z",
+        "expiresAt": "2025-12-01T00:05:00Z"
+      }
+    }
+  }
+}

--- a/examples/aiar-identity/proof-bundle.json
+++ b/examples/aiar-identity/proof-bundle.json
@@ -1,0 +1,19 @@
+{
+  "cardDigest": "sha256:ZXhhbXBsZV9kaWdlc3RfdmFsdWVfaGVyZQ",
+  "issuer": "https://example.com",
+  "kid": "example-key-2025-01",
+  "proofOfPossession": {
+    "protected": "eyJhbGciOiJFUzI1NiIsImtpZCI6ImV4YW1wbGUta2V5LTIwMjUtMDEiLCJ0eXAiOiJwb3Aram3rIn0",
+    "payload": "eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwic3ViIjoiaHR0cHM6Ly9hZ2VudC5leGFtcGxlLmNvbS8ud2VsbC1rbm93bi9hZ2VudC1jYXJkLmpzb24iLCJjYXJkRGlnZXN0Ijoic2hhMjU2OlpleGhiWEJzWlY5a2FXZGxjM1JmZG1Gc2RXVmZhR1Z5WlEiLCJpYXQiOjE3MzU2ODk2MDAsImV4cCI6MTczNTY4OTkwMCwibm9uY2UiOiJhYmNkMTIzNCJ9",
+    "signature": "MEUCIQDExample_PoP_Signature_Base64url_For_Illustration_OnlyIgExample_Value"
+  },
+  "issuedAt": "2025-12-01T00:00:00Z",
+  "expiresAt": "2025-12-01T00:05:00Z",
+  "attestations": [
+    {
+      "type": "uri",
+      "value": "https://trust-registry.example.org/attestations/example-corp-verified",
+      "description": "Example Corp verified agent operator attestation"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

This PR introduces the **Agent Identity and Accountability Reporting (AIAR)** extension (`v0` MVP), a backwards-compatible A2A extension that provides verifiable identity binding for Agent Cards and runtime proof-of-possession for agent endpoints.

**Problem:** The A2A protocol enables agent discovery and communication but does not provide a mechanism for clients to verify that an Agent Card or runtime endpoint is bound to a verifiable issuer identity. Discovery is not identity; runtime auth is not ownership.

**Solution:** AIAR adds opt-in, cryptographic identity primitives using standard formats (JWS, JCS canonicalization) that higher-level trust frameworks can build upon.

### What's included

- **Extension specification** (`docs/extensions/aiar-identity-v0.md`):
  - Agent Card identity params: `issuer`, `kid`, `signedFields`, `jws`, `attestations`
  - Signing target definition using RFC 8785 (JCS) canonicalization
  - Step-by-step verification procedure
  - Message-level opt-in request (`minAssurance`, `acceptableIssuers`, `requireFreshnessSeconds`)
  - Response proof bundle (`cardDigest`, `proofOfPossession`, timestamps)
  - Optional RPC methods: `aiar.getProofBundle`, `aiar.getIssuer`
  - Security considerations (Sybil, replay, key compromise, phishing, privacy)

- **Specification updates** (`docs/specification.md`):
  - AIAR Agent Card example in Section 4.6 (Extension Declaration)
  - Message-level identity request example

- **Extensions list update** (`docs/topics/extensions.md`):
  - AIAR added to the extension list table

- **Example payloads** (`examples/aiar-identity/`):
  - `agent-card.json` — standard Agent Card without AIAR
  - `agent-card.signed.json` — Agent Card with AIAR extension params + JWS
  - `message.request.json` — SendMessage with identity requirements in metadata
  - `message.response.json` — task response with proof bundle in metadata
  - `proof-bundle.json` — standalone proof bundle (as returned by `aiar.getProofBundle`)
  - `README.md` — step-by-step verification guide

### How clients opt in

1. Inspect `capabilities.extensions[]` in the Agent Card for the AIAR URI
2. Include `A2A-Extensions: https://github.com/a2aproject/A2A/extensions/aiar.identity/v0` header
3. Optionally include identity requirements in `SendMessageRequest.metadata`
4. Verify the proof bundle in the response metadata

### What's explicitly out of scope (v0)

- Global governance or federated identity registries
- Certificate revocation infrastructure (CRL/OCSP)
- Reputation systems or behavioral trust metrics
- End-to-end message encryption
- Agent-to-agent mutual authentication
- Automated key rotation (`aiar.rotateKeys` deferred to future version)

### Compatibility

- **No breaking changes**: all AIAR data uses existing extension points (`AgentExtension.params`, `Message.metadata`, `Task.metadata`)
- **No core schema modifications**: no changes to `a2a.proto` or core data structures
- **Graceful degradation**: agents/clients unaware of AIAR are completely unaffected

### Checklist

- [x] `docs/extensions/aiar-identity-v0.md` exists with full spec + examples
- [x] Agent Card schema/docs updated to show extension declaration + AIAR example
- [x] Message schema/docs updated with AIAR request + proof bundle response
- [x] Optional RPC methods defined in spec
- [x] `examples/` folder includes valid JSON payloads + verification README
- [x] No breaking changes; existing schemas remain valid