### PR TITLE
fix(spec): update error examples to use google.rpc.Status format

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1465,14 +1465,25 @@ A2A-Version: 0.5
 
 ```http
 HTTP/1.1 400 Bad Request
-Content-Type: application/problem+json
+Content-Type: application/json
 
 {
-  "type": "https://a2a-protocol.org/errors/version-not-supported",
-  "title": "Protocol Version Not Supported",
-  "status": 400,
-  "detail": "The requested A2A protocol version 0.5 is not supported by this agent",
-  "supportedVersions": ["0.3"]
+  "error": {
+    "code": 400,
+    "status": "FAILED_PRECONDITION",
+    "message": "The requested A2A protocol version 0.5 is not supported by this agent",
+    "details": [
+      {
+        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+        "reason": "VERSION_NOT_SUPPORTED",
+        "domain": "a2a-protocol.org",
+        "metadata": {
+          "requestedVersion": "0.5",
+          "supportedVersions": "0.3"
+        }
+      }
+    ]
+  }
 }
 ```
 
@@ -1595,25 +1606,33 @@ Authorization: Bearer token
 
 ```http
 HTTP/1.1 400 Bad Request
-Content-Type: application/problem+json
+Content-Type: application/json
 
 {
-  "status": 400,
-  "detail": "Invalid parameters",
-  "errors": [
-    {
-      "field": "pageSize",
-      "message": "Must be between 1 and 100 inclusive, got 150"
-    },
-    {
-      "field": "historyLength",
-      "message": "Must be non-negative integer, got -5"
-    },
-    {
-      "field": "status",
-      "message": "Invalid status value 'TASK_STATE_RUNNING'. Must be one of: TASK_STATE_SUBMITTED, TASK_STATE_WORKING, TASK_STATE_COMPLETED, TASK_STATE_FAILED, TASK_STATE_CANCELED, TASK_STATE_REJECTED, TASK_STATE_INPUT_REQUIRED, TASK_STATE_AUTH_REQUIRED"
-    }
-  ]
+  "error": {
+    "code": 400,
+    "status": "INVALID_ARGUMENT",
+    "message": "Invalid parameters",
+    "details": [
+      {
+        "@type": "type.googleapis.com/google.rpc.BadRequest",
+        "fieldViolations": [
+          {
+            "field": "pageSize",
+            "description": "Must be between 1 and 100 inclusive, got 150"
+          },
+          {
+            "field": "historyLength",
+            "description": "Must be non-negative integer, got -5"
+          },
+          {
+            "field": "status",
+            "description": "Invalid status value 'TASK_STATE_RUNNING'. Must be one of: TASK_STATE_SUBMITTED, TASK_STATE_WORKING, TASK_STATE_COMPLETED, TASK_STATE_FAILED, TASK_STATE_CANCELED, TASK_STATE_REJECTED, TASK_STATE_INPUT_REQUIRED, TASK_STATE_AUTH_REQUIRED"
+          }
+        ]
+      }
+    ]
+  }
 }
 ```
 


### PR DESCRIPTION
## Summary

Sections 6.4 (Version Negotiation Error) and 6.5 (Validation Error Example) still showed error payloads using the legacy RFC 7807 `application/problem+json` format, even though Sections 5.4 and 11.6 were updated to use the `google.rpc.Status` JSON representation (AIP-193) in #1600 / #1627.

This PR aligns the two remaining examples with the documented error model:

- **Section 6.4** — Version negotiation error now uses `google.rpc.ErrorInfo` with `FAILED_PRECONDITION` status. Supported-version metadata is preserved inside `ErrorInfo.metadata`.
- **Section 6.5** — Validation error now uses `google.rpc.BadRequest` with `fieldViolations` and `INVALID_ARGUMENT` status. The enum values added by #1801 are preserved.

No other examples in the spec still use `application/problem+json`, so this completes the AIP-193 migration in the workflows section.

The original enum-value inconsistencies described in #1642 were already addressed by #1801; this PR finishes cleaning up the same Section 6.5 example by also bringing its serialization format in line with Section 11.6.

Fixes #1642

## Test plan

- [x] `./scripts/format.sh` runs clean (no markdown changes)
- [x] `markdownlint` against `.github/linters/.markdownlint.json` passes on `docs/specification.md`
- [x] No new spelling-allowlist entries required (all new identifiers already appear elsewhere in the spec)
- [x] Section 6.4 example matches the conventions described in Section 11.6
- [x] Section 6.5 example matches the conventions described in Section 11.6 and preserves the enum values from #1801