### PR TITLE
Add a2a-swift community SDK to community.md

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -71,7 +71,9 @@ These agentic frameworks have built-in A2A integration, making it easy to get st
 
 Community-built SDKs that implement the A2A protocol in additional languages:
 
-- [a2a-swift](https://github.com/Victory-Apps/a2a-swift) — Swift SDK with full v1.0 data model, JSON-RPC routing, SSE streaming, Vapor integration, and testing utilities. Supports macOS, Linux, iOS, tvOS, watchOS.
+- [a2a-swift](https://github.com/Victory-Apps/a2a-swift) — A Swift SDK for the A2A protocol.
+  - **Features**: Full v1.0 data model, JSON-RPC routing, SSE streaming, Vapor integration, and testing utilities.
+  - **Platforms**: macOS, Linux, iOS, tvOS, watchOS.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a **Community SDKs** section to `docs/community.md` with **[a2a-swift](https://github.com/Victory-Apps/a2a-swift)** — a Swift implementation of the A2A protocol.

This is the first community SDK listed on the community page, extending A2A's language coverage to Swift and Apple platforms.

### About a2a-swift
- Full A2A v1.0 data model
- JSON-RPC 2.0 routing with SSE streaming and reconnection
- Vapor web framework integration
- Testing utilities with mocks and fixture builders
- Supports macOS, Linux, iOS, tvOS, watchOS