### PR TITLE
feat: Add QuerySkill() operation for runtime skill capability introspection

### DIFF
--- a/adrs/adr-002-queryskill.md
+++ b/adrs/adr-002-queryskill.md
@@ -13,7 +13,7 @@ The result is that orchestrators either over-delegate (sending tasks to agents t
 We will add a `QuerySkill` RPC to `a2a.proto` as a capability declaration, not a task execution.
 
 The design has three layers:
-1.  **Proto definition**: Add `SkillQueryRequest` and `SkillQueryResult` messages, and the `SkillSupportLevel` enum with values `SUPPORTED`, `PARTIAL`, and `UNSUPPORTED`.
+1.  **Proto definition**: Add `SkillQueryRequest` and `SkillQueryResult` messages, and the `SkillSupportLevel` enum with values `SKILL_SUPPORT_LEVEL_SUPPORTED`, `SKILL_SUPPORT_LEVEL_PARTIAL`, and `SKILL_SUPPORT_LEVEL_UNSUPPORTED`.
 2.  **Protocol binding**: Map to JSON-RPC as `skills/query`, to gRPC as `QuerySkill` on the existing `A2AService`, and to HTTP/REST as `POST /skills/{skill_id}/query`. All bindings must return `UnsupportedOperationError` if the server hasn't declared `capabilities.skill_query: true` in its `AgentCard`.
 3.  **Caching and staleness**: `SkillQueryResult` includes a `cache_ttl_seconds` field. Furthermore, we define `stale-if-error` semantics: if a `QuerySkill` call fails transiently, the orchestrator MAY use a cached `SUPPORTED` result for up to 2 × `cache_ttl_seconds`.
 

--- a/adrs/adr-002-queryskill.md
+++ b/adrs/adr-002-queryskill.md
@@ -1,0 +1,28 @@
+# ADR 002: Dynamic Skill Introspection (`QuerySkill`)
+
+## Status
+Proposed
+
+## Context
+The A2A protocol today relies entirely on the `AgentCard` for capability discovery. That card is a static, cached document published at `/.well-known/agent.json` or accessed via `GetExtendedAgentCard`.
+The problem is that agent capabilities are not truly static. They vary based on load, configuration, runtime environment, available models, feature flags, and context.
+An orchestrator agent has no way to ask: "Can you handle this specific task right now, with these parameters?"
+The result is that orchestrators either over-delegate (sending tasks to agents that will fail) or under-delegate (avoiding agents whose card looks uncertain). There is also no concept of partial capability — an agent that can do 80% of a requested skill but not the full scope cannot express that today.
+
+## Decision
+We will add a `QuerySkill` RPC to `a2a.proto` as a capability declaration, not a task execution.
+
+The design has three layers:
+1.  **Proto definition**: Add `SkillQueryRequest` and `SkillQueryResult` messages, and the `SkillSupportLevel` enum with values `SUPPORTED`, `PARTIAL`, and `UNSUPPORTED`.
+2.  **Protocol binding**: Map to JSON-RPC as `skills/query`, to gRPC as `QuerySkill` on the existing `A2AService`, and to HTTP/REST as `POST /skills/{skill_id}/query`. All bindings must return `UnsupportedOperationError` if the server hasn't declared `capabilities.skill_query: true` in its `AgentCard`.
+3.  **Caching and staleness**: `SkillQueryResult` includes a `cache_ttl_seconds` field. Furthermore, we define `stale-if-error` semantics: if a `QuerySkill` call fails transiently, the orchestrator MAY use a cached `SUPPORTED` result for up to 2 × `cache_ttl_seconds`.
+
+## Consequences
+*   **Proactive Capability Checking:** Clients can avoid costly `SendMessage` calls when the agent cannot support the specific request right now.
+*   **Partial Negotiation:** Agents can use the `constraints` map to request changes from the client (e.g., chunking smaller files).
+*   **Explicit declaration:** Agents must opt into this by setting `skill_query = true` in their capabilities, maintaining compatibility.
+
+## Rejected Alternatives
+*   **Using `GetExtendedAgentCard`:** This is too coarse and cannot carry the varied runtime context without combinatorial explosion.
+*   **Adding a `supports` field to `SendMessage`:** This requires the client to fully constuct the message payload (potentially including large artifacts) before discovering unsupportability, defeating the core benefit.
+*   **Polling `GetTask` for failures:** This is reactive, not proactive, and still incurs the initial transmission and processing cost. The chosen design is proactive and non-destructive.

--- a/specification/a2a.proto
+++ b/specification/a2a.proto
@@ -812,17 +812,17 @@ message ListTaskPushNotificationConfigsResponse {
 // Support level for a requested skill.
 enum SkillSupportLevel {
   SKILL_SUPPORT_LEVEL_UNSPECIFIED = 0;
-  SKILL_SUPPORT_LEVEL_SUPPORTED   = 1;
-  SKILL_SUPPORT_LEVEL_PARTIAL     = 2;
-  SKILL_SUPPORT_LEVEL_UNSUPPORTED = 3;
+  SUPPORTED   = 1;
+  PARTIAL     = 2;
+  UNSUPPORTED = 3;
 }
 
 // Request to query if an agent supports a specific skill dynamically.
 message SkillQueryRequest {
   string tenant   = 1;
   string skill_id = 2;
-  map<string, string> context     = 3;  // runtime parameters
-  map<string, string> metadata    = 4;
+  google.protobuf.Struct context     = 3;  // runtime parameters
+  google.protobuf.Struct metadata    = 4;
 }
 
 // Result of a query for a specific skill's support level.

--- a/specification/a2a.proto
+++ b/specification/a2a.proto
@@ -832,5 +832,5 @@ message SkillQueryResult {
   string             reason        = 3;
   float              confidence    = 4;  // 0.0–1.0
   int32              cache_ttl_seconds = 5;
-  map<string, string> constraints  = 6;  // for PARTIAL level
+  google.protobuf.Struct constraints  = 6;  // for PARTIAL level
 }

--- a/specification/a2a.proto
+++ b/specification/a2a.proto
@@ -812,9 +812,9 @@ message ListTaskPushNotificationConfigsResponse {
 // Support level for a requested skill.
 enum SkillSupportLevel {
   SKILL_SUPPORT_LEVEL_UNSPECIFIED = 0;
-  SUPPORTED   = 1;
-  PARTIAL     = 2;
-  UNSUPPORTED = 3;
+  SKILL_SUPPORT_LEVEL_SUPPORTED = 1;
+  SKILL_SUPPORT_LEVEL_PARTIAL = 2;
+  SKILL_SUPPORT_LEVEL_UNSUPPORTED = 3;
 }
 
 // Request to query if an agent supports a specific skill dynamically.

--- a/specification/a2a.proto
+++ b/specification/a2a.proto
@@ -127,6 +127,18 @@ service A2AService {
       }
     };
   }
+  // Queries if the agent supports a specific skill dynamically.
+  rpc QuerySkill(SkillQueryRequest) returns (SkillQueryResult) {
+    option (google.api.http) = {
+      post: "/skills/{skill_id}/query"
+      body: "*"
+      additional_bindings: {
+        post: "/{tenant}/skills/{skill_id}/query"
+        body: "*"
+      }
+    };
+    option (google.api.method_signature) = "skill_id,context";
+  }
   // Deletes a push notification config for a task.
   rpc DeleteTaskPushNotificationConfig(DeleteTaskPushNotificationConfigRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
@@ -412,6 +424,8 @@ message AgentCapabilities {
   repeated AgentExtension extensions = 3;
   // Indicates if the agent supports providing an extended agent card when authenticated.
   optional bool extended_agent_card = 4;
+  // Indicates if the agent supports dynamic skill querying.
+  optional bool skill_query = 5;
 }
 
 // A declaration of a protocol extension supported by an Agent.
@@ -793,4 +807,30 @@ message ListTaskPushNotificationConfigsResponse {
   repeated TaskPushNotificationConfig configs = 1;
   // A token to retrieve the next page of results, or empty if there are no more results in the list.
   string next_page_token = 2;
+}
+
+// Support level for a requested skill.
+enum SkillSupportLevel {
+  SKILL_SUPPORT_LEVEL_UNSPECIFIED = 0;
+  SKILL_SUPPORT_LEVEL_SUPPORTED   = 1;
+  SKILL_SUPPORT_LEVEL_PARTIAL     = 2;
+  SKILL_SUPPORT_LEVEL_UNSUPPORTED = 3;
+}
+
+// Request to query if an agent supports a specific skill dynamically.
+message SkillQueryRequest {
+  string tenant   = 1;
+  string skill_id = 2;
+  map<string, string> context     = 3;  // runtime parameters
+  map<string, string> metadata    = 4;
+}
+
+// Result of a query for a specific skill's support level.
+message SkillQueryResult {
+  string             skill_id      = 1;
+  SkillSupportLevel  support_level = 2;
+  string             reason        = 3;
+  float              confidence    = 4;  // 0.0–1.0
+  int32              cache_ttl_seconds = 5;
+  map<string, string> constraints  = 6;  // for PARTIAL level
 }


### PR DESCRIPTION
# Description
This PR addresses the need for dynamic capability discovery in the A2A protocol. Currently, orchestrators rely on the static `AgentCard`, which cannot represent multidimensional or runtime-specific constraints (e.g., "Can you process a 500MB audio file right now?"). 

Several active discussions confirm real community pain - #883 , #773 , #921,  #166  all describing the same root cause: no protocol-level mechanism exists for a client to probe whether a remote agent can handle a specific skill at runtime.

This PR introduces the `QuerySkill` RPC to establish a proactive capability declaration standard prior to task execution.

## Changes:
- **Added `QuerySkill` RPC** to `A2AService` in `a2a.proto` for dynamic skill introspection.
- **Added `skill_query` boolean flag** to `AgentCapabilities` so agents can explicitly declare support for this feature.
- **Added `SkillQueryRequest` and `SkillQueryResult` messages**, including a `SkillSupportLevel` enum (`SUPPORTED`, `PARTIAL`, `UNSUPPORTED`).
- **Added ADR-002 (`adr-002-queryskill.md`)** detailing the context, decision, consequences, and rejected alternatives.

## Details:
- Supports negotiation via a `constraints` map for `PARTIAL` support levels.
- Includes a `confidence` float and `reason` string for probabilistic routing.
- Returns a `cache_ttl_seconds` to allow orchestrators to cache results (and utilize `stale-if-error` semantics), preventing the `QuerySkill` RPC from becoming a performance bottleneck.
