### PR TITLE
fix: correct bash array syntax, exception handling, and spec JSON examples

### DIFF
--- a/.mkdocs/macros.py
+++ b/.mkdocs/macros.py
@@ -64,7 +64,7 @@ def define_env(env):
         """Parses a .proto file and renders a message table."""
         try:
             elements = _parse_proto(proto_file)
-        except FileNotFoundError as e:
+        except Exception as e:
             return f'**Error:** {e}'
 
         # Find the specific message object

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1013,7 +1013,7 @@ Agents declare their supported extensions in the [`AgentCard`](#441-agentcard) u
     {
       "url": "https://research-agent.example.com/a2a/v1",
       "protocolBinding": "HTTP+JSON",
-      "protocolVersion": "0.3",
+      "protocolVersion": "0.3"
     }
   ],
   "capabilities": {
@@ -1613,11 +1613,11 @@ Authorization: Bearer token
     "messageId": "6dbc13b5-bd57-4c2b-b503-24e381b6c8d6"
   },
   "configuration": {
-    "pushNotificationConfig": {
+    "taskPushNotificationConfig": {
       "url": "https://client.example.com/webhook/a2a-notifications",
       "token": "secure-client-token-for-task-aaa",
       "authentication": {
-        "schemes": ["Bearer"]
+        "scheme": "Bearer"
       }
     }
   }
@@ -1635,7 +1635,7 @@ Content-Type: application/a2a+json
     "id": "43667960-d455-4453-b0cf-1bae4955270d",
     "contextId": "c295ea44-7543-4f78-b524-7a38915ad6e4",
     "status": {
-      "state": "submitted",
+      "state": "TASK_STATE_SUBMITTED",
       "timestamp": "2024-03-15T11:00:00Z"
     }
   }
@@ -1683,9 +1683,9 @@ Authorization: Bearer token
         "text": "Analyze this image and highlight any faces."
       },
       {
-        "raw": "iVBORw0KGgoAAAANSUhEUgAAAAUA..."
+        "raw": "iVBORw0KGgoAAAANSUhEUgAAAAUA...",
         "filename": "input_image.png",
-        "mediaType": "image/png",
+        "mediaType": "image/png"
       }
     ],
     "messageId": "6dbc13b5-bd57-4c2b-b503-24e381b6c8d6"

--- a/scripts/deploy_root_files.sh
+++ b/scripts/deploy_root_files.sh
@@ -13,7 +13,7 @@ set -e
 
 # --- Configuration ---
 # List of files to copy from the source directory to the root of the gh-pages branch.
-FILES_TO_DEPLOY=("404.html" "robots.txt" "llms.txt", "llms-full.txt")
+FILES_TO_DEPLOY=("404.html" "robots.txt" "llms.txt" "llms-full.txt")
 # The source directory in the main branch where these files are located.
 SOURCE_DIR="docs"
 


### PR DESCRIPTION
## Summary
- Fix stray comma in bash array in `deploy_root_files.sh` that silently prevented `llms.txt` from being deployed to gh-pages
- Broaden exception handling in `proto_to_table` MkDocs macro to match sibling macros and prevent build crashes on proto parse errors
- Fix invalid JSON syntax (trailing/missing commas) and field name/type mismatches against proto definitions in specification examples (§4.6.1, §6.6, §6.7)

## Details

**`scripts/deploy_root_files.sh`**
The comma after `"llms.txt",` in the `FILES_TO_DEPLOY` bash array caused the element to be interpreted as the literal string `llms.txt,` (with trailing comma), so the real `llms.txt` was never found and silently skipped during gh-pages deployment.

**`.mkdocs/macros.py`**
`proto_to_table` only caught `FileNotFoundError`, while the sibling macros `proto_enum_to_table` and `proto_service_to_table` both catch `Exception`. A proto parse error would propagate uncaught and crash the entire MkDocs build instead of rendering a graceful in-page error message.

**`docs/specification.md`**
- §4.6.1: Remove trailing comma in AgentCard JSON example (invalid JSON)
- §6.6: Rename `pushNotificationConfig` to `taskPushNotificationConfig` to match proto field `SendMessageConfiguration.task_push_notification_config`
- §6.6: Change `"schemes": ["Bearer"]` to `"scheme": "Bearer"` to match proto `AuthenticationInfo.scheme` (singular string, not array)
- §6.6: Change `"state": "submitted"` to `"TASK_STATE_SUBMITTED"` to match the SCREAMING_SNAKE_CASE enum convention required by §5.5
- §6.7: Add missing comma after `"raw"` value and remove trailing comma after `"mediaType"` (invalid JSON)

## Test plan
- [ ] Verify `scripts/deploy_root_files.sh` correctly lists all 4 files without trailing comma
- [ ] Verify MkDocs docs build succeeds with the updated macro
- [ ] Verify all modified JSON examples in `specification.md` are valid JSON and match proto definitions

Closes #1656 
