### PR TITLE
docs: add Strale to partners list

### DIFF
--- a/docs/partners.md
+++ b/docs/partners.md
@@ -140,6 +140,7 @@ collaborate effectively with each other and with users.
 - [Solace](https://solace.com/products/agent-mesh/)
 - [Solo.io](https://www.solo.io/)
 - [Stacklok, Inc](https://stacklok.com)
+- [Strale](https://strale.dev)
 - [Supertab](https://www.supertab.co/post/supertab-connect-partners-with-google-cloud-to-enable-ai-agents)
 - [Suzega](https://suzega.com/)
 - [TCS](https://www.tcs.com)


### PR DESCRIPTION
Adds [Strale](https://strale.dev) to the A2A partners list.

Strale is an API capability marketplace for AI agents with a live A2A implementation:

- **Agent Card**: https://api.strale.io/.well-known/agent-card.json
- **A2A endpoint**: `POST https://api.strale.io/a2a` (JSON-RPC: `message/send`, `tasks/get`)
- **273 skills** across compliance, company data (27 countries), financial validation, Web3/DeFi, and developer tools
- **Link header** on all responses: `Link: </.well-known/agent-card.json>; rel="agent-card"`

Also accessible via MCP (Streamable HTTP), REST API, and x402 (USDC micropayments on Base).