### PR TITLE
⚡ Bolt: Use bash built-in file comparison in build_docs.sh

### DIFF
--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -16,16 +16,8 @@ PROTO_TO_SCHEMA_SCRIPT="$ROOT_DIR/scripts/proto_to_json_schema.sh"
 regen_needed() {
   if [ ! -f "$SCHEMA_JSON" ]; then return 0; fi
 
-  local proto_mtime
-  local schema_mtime
-  if [[ "$(uname)" == "Darwin" ]]; then
-    proto_mtime=$(stat -f %m "$PROTO_SRC")
-    schema_mtime=$(stat -f %m "$SCHEMA_JSON")
-  else
-    proto_mtime=$(stat -c %Y "$PROTO_SRC")
-    schema_mtime=$(stat -c %Y "$SCHEMA_JSON")
-  fi
-  [ "$proto_mtime" -gt "$schema_mtime" ]
+  # ⚡ Bolt: Use bash built-in -nt operator to check file modification times instead of spawning external subshells and stat commands
+  [ "$PROTO_SRC" -nt "$SCHEMA_JSON" ]
 }
 
 echo "[build_docs] Checking schema freshness..." >&2


### PR DESCRIPTION
💡 **What**: Replaced the `uname` and `stat` commands with the built-in `-nt` bash operator for comparing file modification times in `scripts/build_docs.sh`.
🎯 **Why**: Using `stat` required spawning multiple external subshells just to check if the protobuf definition is newer than the schema JSON. The built-in `-nt` handles this natively and cross-platform without any subprocess overhead.
📊 **Impact**: Faster execution of the `regen_needed` function during the build pipeline and cleaner, shorter code.
🔬 **Measurement**: Run `bash scripts/build_docs.sh` to confirm the check still correctly prevents or triggers regeneration based on timestamps.

---
*PR created automatically by Jules for task [15601221610429652413](https://jules.google.com/task/15601221610429652413)*