### PR TITLE
docs(Specification.md): Swap Section 4 (Protocol Data Model) with Section 3 (A2A Protocol Operations)

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -222,7 +222,7 @@ The A2A protocol defines a canonical data model using Protocol Buffers. All prot
 
 #### 3.3.3. Push Notification Payload
 
-When a task update occurs, the agent sends an HTTP POST request to the configured webhook URL. The payload uses the same [`StreamResponse`](#323-stream-response) format as streaming operations, allowing push notifications to deliver the same event types as real-time streams.
+When a task update occurs, the agent sends an HTTP POST request to the configured webhook URL. The payload uses the same [`StreamResponse`](#423-stream-response) format as streaming operations, allowing push notifications to deliver the same event types as real-time streams.
 
 **Request Format:**
 
@@ -242,16 +242,16 @@ Content-Type: application/json
 
 **Payload Structure:**
 
-The webhook payload is a [`StreamResponse`](#323-stream-response) object containing exactly one of the following:
+The webhook payload is a [`StreamResponse`](#423-stream-response) object containing exactly one of the following:
 
-- **task**: A [`Task`](#411-task) object with the current task state
-- **message**: A [`Message`](#414-message) object containing a message response
-- **statusUpdate**: A [`TaskStatusUpdateEvent`](#421-taskstatusupdateevent) indicating a status change
-- **artifactUpdate**: A [`TaskArtifactUpdateEvent`](#422-taskartifactupdateevent) indicating artifact updates
+- **task**: A [`Task`](#311-task) object with the current task state
+- **message**: A [`Message`](#314-message) object containing a message response
+- **statusUpdate**: A [`TaskStatusUpdateEvent`](#321-taskstatusupdateevent) indicating a status change
+- **artifactUpdate**: A [`TaskArtifactUpdateEvent`](#322-taskartifactupdateevent) indicating artifact updates
 
 **Authentication:**
 
-The agent MUST include authentication credentials in the request headers as specified in the [`PushNotificationConfig.authentication`](#432-authenticationinfo) field. The format follows standard HTTP authentication patterns (Bearer tokens, Basic auth, etc.).
+The agent MUST include authentication credentials in the request headers as specified in the [`PushNotificationConfig.authentication`](#332-authenticationinfo) field. The format follows standard HTTP authentication patterns (Bearer tokens, Basic auth, etc.).
 
 **Client Responsibilities:**
 
@@ -382,7 +382,7 @@ The A2A protocol supports extensions to provide additional functionality or data
 
 #### 3.6.1. Extension Declaration
 
-Agents declare their supported extensions in the [`AgentCard`](#441-agentcard) using the `extensions` field, which contains an array of [`AgentExtension`](#444-agentextension) objects.
+Agents declare their supported extensions in the [`AgentCard`](#341-agentcard) using the `extensions` field, which contains an array of [`AgentExtension`](#344-agentextension) objects.
 
 *Example: Agent declaring extension support in AgentCard:*
 
@@ -540,22 +540,22 @@ The primary operation for initiating agent interactions. Clients send a message 
 
 **Inputs:**
 
-- [`SendMessageRequest`](#321-sendmessagerequest): Request object containing the message, configuration, and metadata
+- [`SendMessageRequest`](#421-sendmessagerequest): Request object containing the message, configuration, and metadata
 
 **Outputs:**
 
-- [`Task`](#411-task): A task object representing the processing of the message, OR
-- [`Message`](#414-message): A direct response message (for simple interactions that don't require task tracking)
+- [`Task`](#311-task): A task object representing the processing of the message, OR
+- [`Message`](#314-message): A direct response message (for simple interactions that don't require task tracking)
 
 **Errors:**
 
-- [`ContentTypeNotSupportedError`](#332-error-handling): A Media Type provided in the request's message parts is not supported by the agent.
-- [`UnsupportedOperationError`](#332-error-handling): Messages sent to Tasks that are in a terminal state (e.g., completed, canceled, rejected) cannot accept further messages.
-- [`TaskNotFoundError`](#332-error-handling): The task ID does not exist or is not accessible.
+- [`ContentTypeNotSupportedError`](#432-error-handling): A Media Type provided in the request's message parts is not supported by the agent.
+- [`UnsupportedOperationError`](#432-error-handling): Messages sent to Tasks that are in a terminal state (e.g., completed, canceled, rejected) cannot accept further messages.
+- [`TaskNotFoundError`](#432-error-handling): The task ID does not exist or is not accessible.
 
 **Behavior:**
 
-The agent MAY create a new `Task` to process the provided message asynchronously or MAY return a direct `Message` response for simple interactions. The operation MUST return immediately with either task information or response message. Task processing MAY continue asynchronously after the response when a [`Task`](#411-task) is returned.
+The agent MAY create a new `Task` to process the provided message asynchronously or MAY return a direct `Message` response for simple interactions. The operation MUST return immediately with either task information or response message. Task processing MAY continue asynchronously after the response when a [`Task`](#311-task) is returned.
 
 #### 4.1.2. Send Streaming Message
 
@@ -563,29 +563,29 @@ Similar to Send Message but with real-time streaming of updates during processin
 
 **Inputs:**
 
-- [`SendMessageRequest`](#321-sendmessagerequest): Request object containing the message, configuration, and metadata
+- [`SendMessageRequest`](#421-sendmessagerequest): Request object containing the message, configuration, and metadata
 
 **Outputs:**
 
-- [`Stream Response`](#323-stream-response) object containing:
-    - Initial response: [`Task`](#411-task) object OR [`Message`](#414-message) object
-    - Subsequent events following a `Task` MAY include stream of [`TaskStatusUpdateEvent`](#421-taskstatusupdateevent) and [`TaskArtifactUpdateEvent`](#422-taskartifactupdateevent) objects
+- [`Stream Response`](#423-stream-response) object containing:
+    - Initial response: [`Task`](#311-task) object OR [`Message`](#314-message) object
+    - Subsequent events following a `Task` MAY include stream of [`TaskStatusUpdateEvent`](#321-taskstatusupdateevent) and [`TaskArtifactUpdateEvent`](#322-taskartifactupdateevent) objects
 - Final completion indicator
 
 **Errors:**
 
-- [`UnsupportedOperationError`](#332-error-handling): Streaming is not supported by the agent (see [Capability Validation](#334-capability-validation)).
-- [`UnsupportedOperationError`](#332-error-handling): Messages sent to Tasks that are in a terminal state (e.g., completed, canceled, rejected) cannot accept further messages.
-- [`ContentTypeNotSupportedError`](#332-error-handling): A Media Type provided in the request's message parts is not supported by the agent.
-- [`TaskNotFoundError`](#332-error-handling): The task ID does not exist or is not accessible.
+- [`UnsupportedOperationError`](#432-error-handling): Streaming is not supported by the agent (see [Capability Validation](#434-capability-validation)).
+- [`UnsupportedOperationError`](#432-error-handling): Messages sent to Tasks that are in a terminal state (e.g., completed, canceled, rejected) cannot accept further messages.
+- [`ContentTypeNotSupportedError`](#432-error-handling): A Media Type provided in the request's message parts is not supported by the agent.
+- [`TaskNotFoundError`](#432-error-handling): The task ID does not exist or is not accessible.
 
 **Behavior:**
 
 The operation MUST establish a streaming connection for real-time updates. The stream MUST follow one of these patterns:
 
-1. **Message-only stream:** If the agent returns a [`Message`](#414-message), the stream MUST contain exactly one `Message` object and then close immediately. No task tracking or updates are provided.
+1. **Message-only stream:** If the agent returns a [`Message`](#314-message), the stream MUST contain exactly one `Message` object and then close immediately. No task tracking or updates are provided.
 
-2. **Task lifecycle stream:** If the agent returns a [`Task`](#411-task), the stream MUST begin with the Task object, followed by zero or more [`TaskStatusUpdateEvent`](#421-taskstatusupdateevent) or [`TaskArtifactUpdateEvent`](#422-taskartifactupdateevent) objects. The stream MUST close when the task reaches a terminal state (e.g. completed, failed, canceled, rejected).
+2. **Task lifecycle stream:** If the agent returns a [`Task`](#311-task), the stream MUST begin with the Task object, followed by zero or more [`TaskStatusUpdateEvent`](#321-taskstatusupdateevent) or [`TaskArtifactUpdateEvent`](#322-taskartifactupdateevent) objects. The stream MUST close when the task reaches a terminal state (e.g. completed, failed, canceled, rejected).
 
 The agent MAY return a `Task` for complex processing with status/artifact updates or MAY return a `Message` for direct streaming responses without task overhead. The implementation MUST provide immediate feedback on progress and intermediate results.
 
@@ -597,15 +597,15 @@ Retrieves the current state (including status, artifacts, and optionally history
 
 {{ proto_to_table("GetTaskRequest") }}
 
-See [History Length Semantics](#324-history-length-semantics) for details about `historyLength`.
+See [History Length Semantics](#424-history-length-semantics) for details about `historyLength`.
 
 **Outputs:**
 
-- [`Task`](#411-task): Current state and artifacts of the requested task
+- [`Task`](#311-task): Current state and artifacts of the requested task
 
 **Errors:**
 
-- [`TaskNotFoundError`](#332-error-handling): The task ID does not exist or is not accessible.
+- [`TaskNotFoundError`](#432-error-handling): The task ID does not exist or is not accessible.
 
 #### 4.1.4. List Tasks
 
@@ -649,12 +649,12 @@ Requests the cancellation of an ongoing task. The server will attempt to cancel 
 
 **Outputs:**
 
-- Updated [`Task`](#411-task) with cancellation status
+- Updated [`Task`](#311-task) with cancellation status
 
 **Errors:**
 
-- [`TaskNotCancelableError`](#332-error-handling): The task is not in a cancelable state (e.g., already completed, failed, or canceled).
-- [`TaskNotFoundError`](#332-error-handling): The task ID does not exist or is not accessible.
+- [`TaskNotCancelableError`](#432-error-handling): The task is not in a cancelable state (e.g., already completed, failed, or canceled).
+- [`TaskNotFoundError`](#432-error-handling): The task ID does not exist or is not accessible.
 
 **Behavior:**
 
@@ -672,15 +672,15 @@ Establishes a streaming connection to receive updates for an existing task.
 
 **Outputs:**
 
-- [`Stream Response`](#323-stream-response) object containing:
-    - Initial response: [`Task`](#411-task) object with current state
-    - Stream of [`TaskStatusUpdateEvent`](#421-taskstatusupdateevent) and [`TaskArtifactUpdateEvent`](#422-taskartifactupdateevent) objects
+- [`Stream Response`](#423-stream-response) object containing:
+    - Initial response: [`Task`](#311-task) object with current state
+    - Stream of [`TaskStatusUpdateEvent`](#321-taskstatusupdateevent) and [`TaskArtifactUpdateEvent`](#322-taskartifactupdateevent) objects
 
 **Errors:**
 
-- [`UnsupportedOperationError`](#332-error-handling): Streaming is not supported by the agent (see [Capability Validation](#334-capability-validation)).
-- [`TaskNotFoundError`](#332-error-handling): The task ID does not exist or is not accessible.
-- [`UnsupportedOperationError`](#332-error-handling): The operation is attempted on a task that is in a terminal state (`completed`, `failed`, `canceled`, or `rejected`).
+- [`UnsupportedOperationError`](#432-error-handling): Streaming is not supported by the agent (see [Capability Validation](#434-capability-validation)).
+- [`TaskNotFoundError`](#432-error-handling): The task ID does not exist or is not accessible.
+- [`UnsupportedOperationError`](#432-error-handling): The operation is attempted on a task that is in a terminal state (`completed`, `failed`, `canceled`, or `rejected`).
 
 **Behavior:**
 
@@ -701,16 +701,16 @@ Creates a push notification configuration for a task to receive asynchronous upd
 
 **Outputs:**
 
-- [`PushNotificationConfig`](#431-pushnotificationconfig): Created configuration with assigned ID
+- [`PushNotificationConfig`](#331-pushnotificationconfig): Created configuration with assigned ID
 
 **Errors:**
 
-- [`PushNotificationNotSupportedError`](#332-error-handling): Push notifications are not supported by the agent (see [Capability Validation](#334-capability-validation)).
-- [`TaskNotFoundError`](#332-error-handling): The task ID does not exist or is not accessible.
+- [`PushNotificationNotSupportedError`](#432-error-handling): Push notifications are not supported by the agent (see [Capability Validation](#434-capability-validation)).
+- [`TaskNotFoundError`](#432-error-handling): The task ID does not exist or is not accessible.
 
 **Behavior:**
 
-The operation MUST establish a webhook endpoint for task update notifications. When task updates occur, the agent will send HTTP POST requests to the configured webhook URL with [`StreamResponse`](#323-stream-response) payloads (see [Push Notification Payload](#433-push-notification-payload) for details). This operation is only available if the agent supports push notifications capability. The configuration MUST persist until task completion or explicit deletion.
+The operation MUST establish a webhook endpoint for task update notifications. When task updates occur, the agent will send HTTP POST requests to the configured webhook URL with [`StreamResponse`](#423-stream-response) payloads (see [Push Notification Payload](#333-push-notification-payload) for details). This operation is only available if the agent supports push notifications capability. The configuration MUST persist until task completion or explicit deletion.
 
  <span id="tasks-push-notification-config-operations"></span><span id="grpc-push-notification-operations"></span><span id="push-notification-operations"></span>
 
@@ -726,12 +726,12 @@ Retrieves an existing push notification configuration for a task.
 
 **Outputs:**
 
-- [`PushNotificationConfig`](#431-pushnotificationconfig): The requested configuration
+- [`PushNotificationConfig`](#331-pushnotificationconfig): The requested configuration
 
 **Errors:**
 
-- [`PushNotificationNotSupportedError`](#332-error-handling): Push notifications are not supported by the agent (see [Capability Validation](#334-capability-validation)).
-- [`TaskNotFoundError`](#332-error-handling): The push notification configuration does not exist.
+- [`PushNotificationNotSupportedError`](#432-error-handling): Push notifications are not supported by the agent (see [Capability Validation](#434-capability-validation)).
+- [`TaskNotFoundError`](#432-error-handling): The push notification configuration does not exist.
 
 **Behavior:**
 
@@ -751,8 +751,8 @@ Retrieves all push notification configurations for a task.
 
 **Errors:**
 
-- [`PushNotificationNotSupportedError`](#332-error-handling): Push notifications are not supported by the agent (see [Capability Validation](#334-capability-validation)).
-- [`TaskNotFoundError`](#332-error-handling): The task ID does not exist or is not accessible.
+- [`PushNotificationNotSupportedError`](#432-error-handling): Push notifications are not supported by the agent (see [Capability Validation](#434-capability-validation)).
+- [`TaskNotFoundError`](#432-error-handling): The task ID does not exist or is not accessible.
 
 **Behavior:**
 
@@ -772,8 +772,8 @@ Removes a push notification configuration for a task.
 
 **Errors:**
 
-- [`PushNotificationNotSupportedError`](#332-error-handling): Push notifications are not supported by the agent (see [Capability Validation](#334-capability-validation)).
-- [`TaskNotFoundError`](#332-error-handling): The task ID does not exist.
+- [`PushNotificationNotSupportedError`](#432-error-handling): Push notifications are not supported by the agent (see [Capability Validation](#434-capability-validation)).
+- [`TaskNotFoundError`](#432-error-handling): The task ID does not exist.
 
 **Behavior:**
 
@@ -789,12 +789,12 @@ Retrieves a potentially more detailed version of the Agent Card after the client
 
 **Outputs:**
 
-- [`AgentCard`](#441-agentcard): A complete Agent Card object, which may contain additional details or skills not present in the public card
+- [`AgentCard`](#341-agentcard): A complete Agent Card object, which may contain additional details or skills not present in the public card
 
 **Errors:**
 
-- [`UnsupportedOperationError`](#332-error-handling): The agent does not support authenticated extended cards (see [Capability Validation](#334-capability-validation)).
-- [`ExtendedAgentCardNotConfiguredError`](#332-error-handling): The agent declares support but does not have an extended agent card configured.
+- [`UnsupportedOperationError`](#432-error-handling): The agent does not support authenticated extended cards (see [Capability Validation](#434-capability-validation)).
+- [`ExtendedAgentCardNotConfiguredError`](#432-error-handling): The agent declares support but does not have an extended agent card configured.
 
 **Behavior:**
 
@@ -819,15 +819,15 @@ This section defines common parameter objects used across multiple operations.
 
 **Execution Mode:**
 
-The `return_immediately` field in [`SendMessageConfiguration`](#322-sendmessageconfiguration) controls whether the operation returns immediately or waits for task completion. Operations are blocking by default:
+The `return_immediately` field in [`SendMessageConfiguration`](#422-sendmessageconfiguration) controls whether the operation returns immediately or waits for task completion. Operations are blocking by default:
 
 - **Blocking (`return_immediately: false` or unset)**: The operation MUST wait until the task reaches a terminal state (`COMPLETED`, `FAILED`, `CANCELED`, `REJECTED`) or an interrupted state (`INPUT_REQUIRED`, `AUTH_REQUIRED`) before returning. The response MUST include the latest task state with all artifacts and status information. This is the default behavior.
 
-- **Non-Blocking (`return_immediately: true`)**: The operation MUST return immediately after creating the task, even if processing is still in progress. The returned task will have an in-progress state (e.g., `working`, `input_required`). It is the caller's responsibility to poll for updates using [Get Task](#313-get-task), subscribe via [Subscribe to Task](#316-subscribe-to-task), or receive updates via push notifications.
+- **Non-Blocking (`return_immediately: true`)**: The operation MUST return immediately after creating the task, even if processing is still in progress. The returned task will have an in-progress state (e.g., `working`, `input_required`). It is the caller's responsibility to poll for updates using [Get Task](#413-get-task), subscribe via [Subscribe to Task](#416-subscribe-to-task), or receive updates via push notifications.
 
 The `return_immediately` field has no effect:
 
-- when the operation returns a direct [`Message`](#414-message) response instead of a task.
+- when the operation returns a direct [`Message`](#314-message) response instead of a task.
 - for streaming operations, which always return updates in real-time.
 - on configured push notification configurations, which operates independently of execution mode.
 
@@ -850,7 +850,7 @@ The `historyLength` parameter appears in multiple operations and controls how mu
 
 #### 4.2.5. Metadata
 
-A flexible key-value map for passing additional context or parameters with operations. Metadata keys and are strings and values can be any valid value that can be represented in JSON. [`Extensions`](#46-extensions) can be used to strongly type metadata values for specific use cases.
+A flexible key-value map for passing additional context or parameters with operations. Metadata keys and are strings and values can be any valid value that can be represented in JSON. [`Extensions`](#36-extensions) can be used to strongly type metadata values for specific use cases.
 
 #### 4.2.6 Service Parameters
 
@@ -861,7 +861,7 @@ A key-value map for passing horizontally applicable context or parameters with c
 | Name             | Description                                                                                                                                             | Example Value                                                                                 |
 | :--------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------ | :-------------------------------------------------------------------------------------------- |
 | `A2A-Extensions` | Comma-separated list of extension URIs that the client wants to use for the request                                                                     | `https://example.com/extensions/geolocation/v1,https://standards.org/extensions/citations/v1` |
-| `A2A-Version`    | The A2A protocol version that the client is using. If the version is not supported, the agent returns [`VersionNotSupportedError`](#332-error-handling) | `0.3`                                                                                         |
+| `A2A-Version`    | The A2A protocol version that the client is using. If the version is not supported, the agent returns [`VersionNotSupportedError`](#432-error-handling) | `0.3`                                                                                         |
 
 As service parameter names MAY need to co-exist with other parameters defined by the underlying transport protocol or infrastructure, all service parameters defined by this specification will be prefixed with `a2a-`.
 
@@ -942,16 +942,16 @@ Protocol bindings **MUST** map these elements to their native error representati
 
 #### 4.3.3. Asynchronous Processing
 
-A2A operations are designed for asynchronous task execution. Operations return immediately with either [`Task`](#411-task) objects or [`Message`](#414-message) objects, and when a Task is returned, processing continues in the background. Clients retrieve task updates through polling, streaming, or push notifications (see [Section 3.5](#35-task-update-delivery-mechanisms)). Agents MAY accept additional messages for tasks in non-terminal states to enable multi-turn interactions (see [Section 3.4](#34-multi-turn-interactions)).
+A2A operations are designed for asynchronous task execution. Operations return immediately with either [`Task`](#311-task) objects or [`Message`](#314-message) objects, and when a Task is returned, processing continues in the background. Clients retrieve task updates through polling, streaming, or push notifications (see [Section 4.5](#45-task-update-delivery-mechanisms)). Agents MAY accept additional messages for tasks in non-terminal states to enable multi-turn interactions (see [Section 4.4](#44-multi-turn-interactions)).
 
 #### 4.3.4. Capability Validation
 
-Agents declare optional capabilities in their [`AgentCard`](#441-agentcard). When clients attempt to use operations or features that require capabilities not declared as supported in the Agent Card, the agent **MUST** return an appropriate error response:
+Agents declare optional capabilities in their [`AgentCard`](#341-agentcard). When clients attempt to use operations or features that require capabilities not declared as supported in the Agent Card, the agent **MUST** return an appropriate error response:
 
-- **Push Notifications**: If `AgentCard.capabilities.pushNotifications` is `false` or not present, operations related to push notification configuration (Create, Get, List, Delete) **MUST** return [`PushNotificationNotSupportedError`](#332-error-handling).
-- **Streaming**: If `AgentCard.capabilities.streaming` is `false` or not present, attempts to use `SendStreamingMessage` or `SubscribeToTask` operations **MUST** return [`UnsupportedOperationError`](#332-error-handling).
-- **Extended Agent Card**: If `AgentCard.capabilities.extendedAgentCard` is `false` or not present, attempts to call the Get Extended Agent Card operation **MUST** return [`UnsupportedOperationError`](#332-error-handling). If the agent declares support but has not configured an extended card, it **MUST** return [`ExtendedAgentCardNotConfiguredError`](#332-error-handling).
-- **Extensions**: When a server requests use of an extension marked as `required: true` in the Agent Card but the client does not declare support for it, the agent **MUST** return [`ExtensionSupportRequiredError`](#332-error-handling).
+- **Push Notifications**: If `AgentCard.capabilities.pushNotifications` is `false` or not present, operations related to push notification configuration (Create, Get, List, Delete) **MUST** return [`PushNotificationNotSupportedError`](#432-error-handling).
+- **Streaming**: If `AgentCard.capabilities.streaming` is `false` or not present, attempts to use `SendStreamingMessage` or `SubscribeToTask` operations **MUST** return [`UnsupportedOperationError`](#432-error-handling).
+- **Extended Agent Card**: If `AgentCard.capabilities.extendedAgentCard` is `false` or not present, attempts to call the Get Extended Agent Card operation **MUST** return [`UnsupportedOperationError`](#432-error-handling). If the agent declares support but has not configured an extended card, it **MUST** return [`ExtendedAgentCardNotConfiguredError`](#432-error-handling).
+- **Extensions**: When a server requests use of an extension marked as `required: true` in the Agent Card but the client does not declare support for it, the agent **MUST** return [`ExtensionSupportRequiredError`](#432-error-handling).
 
 Clients **SHOULD** validate capability support by examining the Agent Card before attempting operations that require optional capabilities.
 
@@ -961,12 +961,12 @@ The A2A protocol supports multi-turn conversations through context identifiers a
 
 #### 4.4.1. Context Identifier Semantics
 
-A `contextId` is an identifier that logically groups multiple related [`Task`](#411-task) and [`Message`](#414-message) objects, providing continuity across a series of interactions.
+A `contextId` is an identifier that logically groups multiple related [`Task`](#311-task) and [`Message`](#314-message) objects, providing continuity across a series of interactions.
 
 **Generation and Assignment:**
 
-- Agents **MAY** generate a new `contextId` when processing a [`Message`](#414-message) that does not include a `contextId` field
-- If an agent generates a new `contextId`, it **MUST** be included in the response (either [`Task`](#411-task) or [`Message`](#414-message))
+- Agents **MAY** generate a new `contextId` when processing a [`Message`](#314-message) that does not include a `contextId` field
+- If an agent generates a new `contextId`, it **MUST** be included in the response (either [`Task`](#311-task) or [`Message`](#314-message))
 - Agents **MAY** accept and preserve client-provided `contextId` values
 - If an agent cannot accept a client-provided `contextId`, it **MUST** reject the request with an error and **MUST NOT** generate a new `contextId` for the response
 - Clients **SHOULD NOT** provide a client-generated `contextId` to a server unless they understand how the server will process that `contextId`
@@ -974,22 +974,22 @@ A `contextId` is an identifier that logically groups multiple related [`Task`](#
 
 **Grouping and Scope:**
 
-- A `contextId` logically groups multiple [`Task`](#411-task) objects and [`Message`](#414-message) objects that are part of the same conversational context
+- A `contextId` logically groups multiple [`Task`](#311-task) objects and [`Message`](#314-message) objects that are part of the same conversational context
 - All tasks and messages with the same `contextId` **SHOULD** be treated as part of the same conversational session
 - Agents **MAY** use the `contextId` to maintain internal state, conversational history, or LLM context across multiple interactions
 - Agents **MAY** implement context expiration or cleanup policies and **SHOULD** document any such policies
 
 #### 4.4.2. Task Identifier Semantics
 
-A `taskId` is a unique identifier for a [`Task`](#411-task) object, representing a stateful unit of work with a defined lifecycle.
+A `taskId` is a unique identifier for a [`Task`](#311-task) object, representing a stateful unit of work with a defined lifecycle.
 
 **Generation and Assignment:**
 
-- Task IDs are **server-generated** when a new task is created in response to a [`Message`](#414-message)
+- Task IDs are **server-generated** when a new task is created in response to a [`Message`](#314-message)
 - Agents **MUST** generate a unique `taskId` for each new task they create
-- The generated `taskId` **MUST** be included in the [`Task`](#411-task) object returned to the client
-- When a client includes a `taskId` in a [`Message`](#414-message), it **MUST** reference an existing task
-- Agents **MUST** return a [`TaskNotFoundError`](#332-error-handling) if the provided `taskId` does not correspond to an existing task
+- The generated `taskId` **MUST** be included in the [`Task`](#311-task) object returned to the client
+- When a client includes a `taskId` in a [`Message`](#314-message), it **MUST** reference an existing task
+- Agents **MUST** return a [`TaskNotFoundError`](#432-error-handling) if the provided `taskId` does not correspond to an existing task
 - Client-provided `taskId` values for creating new tasks is **NOT** supported
 
 #### 4.4.3. Multi-Turn Conversation Patterns
@@ -998,12 +998,12 @@ The A2A protocol supports several patterns for multi-turn interactions:
 
 **Context Continuity:**
 
-- [`Task`](#411-task) objects maintain conversation context through the `contextId` field
+- [`Task`](#311-task) objects maintain conversation context through the `contextId` field
 - Clients **MAY** include the `contextId` in subsequent messages to indicate continuation of a previous interaction
 - Clients **MAY** use `taskId` (with or without `contextId`) to continue or refine a specific task
 - Clients **MAY** use `contextId` without `taskId` to start a new task within an existing conversation context
 - Agents **MUST** infer `contextId` from the task if only `taskId` is provided
-- Agents **MUST** reject messages containing mismatching `contextId` and `taskId` (i.e., the provided `contextId` is different from that of the referenced [`Task`](#411-task)).
+- Agents **MUST** reject messages containing mismatching `contextId` and `taskId` (i.e., the provided `contextId` is different from that of the referenced [`Task`](#311-task)).
 
 **Input Required State:**
 
@@ -1013,7 +1013,7 @@ The A2A protocol supports several patterns for multi-turn interactions:
 **Follow-up Messages:**
 
 - Clients can send additional messages with `taskId` references to continue or refine existing tasks
-- Clients **SHOULD** use the `referenceTaskIds` field in [`Message`](#414-message) to explicitly reference related tasks
+- Clients **SHOULD** use the `referenceTaskIds` field in [`Message`](#314-message) to explicitly reference related tasks
 - Agents **SHOULD** use referenced tasks to understand the context and intent of follow-up requests
 
 **Context Inheritance:**
@@ -1029,7 +1029,7 @@ The A2A protocol provides three complementary mechanisms for clients to receive 
 
 **Polling (Get Task):**
 
-- Client periodically calls Get Task ([Section 3.1.3](#313-get-task)) to check task status
+- Client periodically calls Get Task ([Section 4.1.3](#413-get-task)) to check task status
 - Simple to implement, works with all protocol bindings
 - Higher latency, potential for unnecessary requests
 - Best for: Simple integrations, infrequent updates, clients behind restrictive firewalls
@@ -1037,7 +1037,7 @@ The A2A protocol provides three complementary mechanisms for clients to receive 
 **Streaming:**
 
 - Real-time delivery of events as they occur
-- Operations: Stream Message ([Section 3.1.2](#312-send-streaming-message)) and Subscribe to Task ([Section 3.1.6](#316-subscribe-to-task))
+- Operations: Stream Message ([Section 4.1.2](#412-send-streaming-message)) and Subscribe to Task ([Section 4.1.6](#416-subscribe-to-task))
 - Low latency, efficient for frequent updates
 - Requires persistent connection support
 - Best for: Interactive applications, real-time dashboards, live progress monitoring
@@ -1049,8 +1049,8 @@ The A2A protocol provides three complementary mechanisms for clients to receive 
 - Client does not maintain persistent connection
 - Asynchronous delivery, client must be reachable via HTTP
 - Best for: Server-to-server integrations, long-running tasks, event-driven architectures
-- Operations: Create ([Section 3.1.7](#317-create-push-notification-config)), Get ([Section 3.1.8](#76-taskspushnotificationconfigget)), List ([Section 3.1.9](#319-list-push-notification-configs)), Delete ([Section 3.1.10](#3110-delete-push-notification-config))
-- Event types: TaskStatusUpdateEvent ([Section 4.2.1](#421-taskstatusupdateevent)), TaskArtifactUpdateEvent ([Section 4.2.2](#422-taskartifactupdateevent)), WebHook payloads ([Section 4.3](#43-push-notification-objects))
+- Operations: Create ([Section 4.1.7](#417-create-push-notification-config)), Get ([Section 4.1.8](#76-taskspushnotificationconfigget)), List ([Section 4.1.9](#419-list-push-notification-configs)), Delete ([Section 4.1.10](#4110-delete-push-notification-config))
+- Event types: TaskStatusUpdateEvent ([Section 3.2.1](#321-taskstatusupdateevent)), TaskArtifactUpdateEvent ([Section 3.2.2](#322-taskartifactupdateevent)), WebHook payloads ([Section 3.3](#33-push-notification-objects))
 - Requires `AgentCard.capabilities.pushNotifications` to be `true`
 - Regardless of the protocol binding being used by the agent, WebHook calls use plain HTTP and the JSON payloads as defined in the HTTP protocol binding
 
@@ -1079,7 +1079,7 @@ This capability enables scenarios such as:
 
 #### 4.5.3. Push Notification Delivery
 
-Push notifications are delivered via HTTP POST to client-registered webhook endpoints. The delivery semantics and reliability guarantees are defined in [Section 4.3](#43-push-notification-objects).
+Push notifications are delivered via HTTP POST to client-registered webhook endpoints. The delivery semantics and reliability guarantees are defined in [Section 3.3](#33-push-notification-objects).
 
 ### 4.6 Versioning
 
@@ -1112,7 +1112,7 @@ Accept: application/json
 
 #### 4.6.2 Server Responsibilities
 
-Agents MUST process requests using the semantics of the requested `A2A-Version` (matching `Major.Minor`). If the version is not supported by the interface, agents MUST return a [`VersionNotSupportedError`](#332-error-handling).
+Agents MUST process requests using the semantics of the requested `A2A-Version` (matching `Major.Minor`). If the version is not supported by the interface, agents MUST return a [`VersionNotSupportedError`](#432-error-handling).
 
 Agents MUST interpret empty value as 0.3 version.
 
@@ -1175,7 +1175,7 @@ When an agent supports multiple protocols, all supported protocols **MUST**:
 
 ### 5.4. Error Code Mappings
 
-All A2A-specific errors defined in [Section 3.3.2](#332-error-handling) **MUST** be mapped to binding-specific error representations. The following table provides the canonical mappings for each standard protocol binding:
+All A2A-specific errors defined in [Section 4.3.2](#432-error-handling) **MUST** be mapped to binding-specific error representations. The following table provides the canonical mappings for each standard protocol binding:
 
 | A2A Error Type                        | JSON-RPC Code | gRPC Status           | HTTP Status                  |
 | :------------------------------------ | :------------ | :-------------------- | :--------------------------- |
@@ -1947,9 +1947,9 @@ If the client is itself an A2A agent actively processing a Task, the client may 
 
 Clients may not be aware of when the agent receives credentials out-of-band and subsequently continues Task processing. If a client does not have an active response stream open with the agent, the client risks missing Task updates. To avoid this, a client SHOULD perform one of the following:
 
-- Subscribe to a stream of events for the Task using the [Subscribe to Task](#316-subscribe-to-task) operation
-- Register a webhook to receive events, if supported by the agent, using the [Create Push Notification Config](#317-create-push-notification-config) operation
-- Begin polling the Task using the [Get Task](#313-get-task) operation
+- Subscribe to a stream of events for the Task using the [Subscribe to Task](#416-subscribe-to-task) operation
+- Register a webhook to receive events, if supported by the agent, using the [Create Push Notification Config](#417-create-push-notification-config) operation
+- Begin polling the Task using the [Get Task](#413-get-task) operation
 
 #### 7.6.3 In-Task Authorization Security Considerations
 
@@ -2057,7 +2057,7 @@ After applying RFC 8785:
 
 #### 8.4.2. Signature Format
 
-Signatures use the JSON Web Signature (JWS) format as defined in [RFC 7515](https://tools.ietf.org/html/rfc7515). The [`AgentCardSignature`](#447-agentcardsignature) object represents JWS components using three fields:
+Signatures use the JSON Web Signature (JWS) format as defined in [RFC 7515](https://tools.ietf.org/html/rfc7515). The [`AgentCardSignature`](#347-agentcardsignature) object represents JWS components using three fields:
 
 - **`protected`** (required, string): Base64url-encoded JSON object containing the JWS Protected Header
 - **`signature`** (required, string): Base64url-encoded signature value
@@ -2240,7 +2240,7 @@ The JSON-RPC protocol binding provides a simple, HTTP-based interface using JSON
 
 ### 9.2. Service Parameter Transmission
 
-A2A service parameters defined in [Section 3.2.6](#326-service-parameters) **MUST** be transmitted using standard HTTP request headers, as JSON-RPC 2.0 operates over HTTP(S).
+A2A service parameters defined in [Section 4.2.6](#426-service-parameters) **MUST** be transmitted using standard HTTP request headers, as JSON-RPC 2.0 operates over HTTP(S).
 
 **Service Parameter Requirements:**
 
@@ -2296,7 +2296,7 @@ Sends a message to initiate or continue a task.
 }
 ```
 
-**Referenced Objects:** [`SendMessageRequest`](#321-sendmessagerequest), [`Message`](#414-message)
+**Referenced Objects:** [`SendMessageRequest`](#421-sendmessagerequest), [`Message`](#314-message)
 
 **Response:**
 
@@ -2312,7 +2312,7 @@ Sends a message to initiate or continue a task.
   }
 ```
 
-**Referenced Objects:** [`Task`](#411-task), [`Message`](#414-message)
+**Referenced Objects:** [`Task`](#311-task), [`Message`](#314-message)
 
 #### 9.4.2. `SendStreamingMessage`
 
@@ -2328,7 +2328,7 @@ data: {"jsonrpc": "2.0", "id": 1, "result": { /* StreamResponse object */ }}
 data: {"jsonrpc": "2.0", "id": 1, "result": { /* StreamResponse object */ }}
 ```
 
-**Referenced Objects:** [`StreamResponse`](#323-stream-response)
+**Referenced Objects:** [`StreamResponse`](#423-stream-response)
 
 #### 9.4.3. `GetTask`
 
@@ -2431,7 +2431,7 @@ Retrieves an extended Agent Card.
 
 ### 9.5. Error Handling
 
-JSON-RPC error responses use the standard [JSON-RPC 2.0 error object](https://www.jsonrpc.org/specification#error_object) structure, which maps to the generic A2A error model defined in [Section 3.3.2](#332-error-handling) as follows:
+JSON-RPC error responses use the standard [JSON-RPC 2.0 error object](https://www.jsonrpc.org/specification#error_object) structure, which maps to the generic A2A error model defined in [Section 4.3.2](#432-error-handling) as follows:
 
 - **Error Code**: Mapped to `error.code` (numeric JSON-RPC error code)
 - **Error Message**: Mapped to `error.message` (human-readable string)
@@ -2516,7 +2516,7 @@ The gRPC Protocol Binding provides a high-performance, strongly-typed interface 
 
 ### 10.2. Service Parameter Transmission
 
-A2A service parameters defined in [Section 3.2.6](#326-service-parameters) **MUST** be transmitted using gRPC metadata (headers).
+A2A service parameters defined in [Section 4.2.6](#426-service-parameters) **MUST** be transmitted using gRPC metadata (headers).
 
 **Service Parameter Requirements:**
 
@@ -2581,7 +2581,7 @@ Retrieves task status.
 
 {{ proto_to_table("GetTaskRequest") }}
 
-**Response:** See [`Task`](#411-task) object definition.
+**Response:** See [`Task`](#311-task) object definition.
 
 #### 10.4.4. ListTasks
 
@@ -2603,7 +2603,7 @@ Cancels a running task.
 
 {{ proto_to_table("CancelTaskRequest") }}
 
-**Response:** See [`Task`](#411-task) object definition.
+**Response:** See [`Task`](#311-task) object definition.
 
 #### 10.4.6. SubscribeToTask
 
@@ -2623,7 +2623,7 @@ Creates a push notification configuration for a task.
 
 {{ proto_to_table("CreateTaskPushNotificationConfigRequest") }}
 
-**Response:** See [`PushNotificationConfig`](#431-pushnotificationconfig) object definition.
+**Response:** See [`PushNotificationConfig`](#331-pushnotificationconfig) object definition.
 
 #### 10.4.8. GetTaskPushNotificationConfig
 
@@ -2633,7 +2633,7 @@ Retrieves an existing push notification configuration for a task.
 
 {{ proto_to_table("GetTaskPushNotificationConfigRequest") }}
 
-**Response:** See [`PushNotificationConfig`](#431-pushnotificationconfig) object definition.
+**Response:** See [`PushNotificationConfig`](#331-pushnotificationconfig) object definition.
 
 #### 10.4.9. ListTaskPushNotificationConfigs
 
@@ -2665,7 +2665,7 @@ Retrieves the agent's extended capability card after authentication.
 
 {{ proto_to_table("GetExtendedAgentCardRequest") }}
 
-**Response:** See [`AgentCard`](#441-agentcard) object definition.
+**Response:** See [`AgentCard`](#341-agentcard) object definition.
 
 ### 10.5. gRPC-Specific Data Types
 
@@ -2677,7 +2677,7 @@ Resource wrapper for push notification configurations. This is a gRPC-specific t
 
 ### 10.6. Error Handling
 
-gRPC error responses use the standard [gRPC status](https://grpc.io/docs/guides/error/) structure with [google.rpc.Status](https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto), which maps to the generic A2A error model defined in [Section 3.3.2](#332-error-handling) as follows:
+gRPC error responses use the standard [gRPC status](https://grpc.io/docs/guides/error/) structure with [google.rpc.Status](https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto), which maps to the generic A2A error model defined in [Section 4.3.2](#432-error-handling) as follows:
 
 - **Error Code**: Mapped to `status.code` (gRPC status code enum)
 - **Error Message**: Mapped to `status.message` (human-readable string)
@@ -2755,7 +2755,7 @@ The HTTP+JSON protocol binding provides a RESTful interface using standard HTTP 
 
 ### 11.2. Service Parameter Transmission
 
-A2A service parameters defined in [Section 3.2.6](#326-service-parameters) **MUST** be transmitted using standard HTTP request headers.
+A2A service parameters defined in [Section 4.2.6](#426-service-parameters) **MUST** be transmitted using standard HTTP request headers.
 
 **Service Parameter Requirements:**
 
@@ -2828,7 +2828,7 @@ Content-Type: application/json
 }
 ```
 
-**Referenced Objects:** [`SendMessageRequest`](#321-sendmessagerequest), [`Message`](#414-message)
+**Referenced Objects:** [`SendMessageRequest`](#421-sendmessagerequest), [`Message`](#314-message)
 
 **Response:**
 
@@ -2847,7 +2847,7 @@ Content-Type: application/json
 }
 ```
 
-**Referenced Objects:** [`Task`](#411-task)
+**Referenced Objects:** [`Task`](#311-task)
 
 ### 11.5. Query Parameter Naming for Request Parameters
 
@@ -2896,7 +2896,7 @@ All query parameter values **MUST** be properly URL-encoded per [RFC 3986](https
 
 ### 11.6. Error Handling
 
-HTTP error responses use the [google.rpc.Status](https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto) JSON representation, which maps to the generic A2A error model defined in [Section 3.3.2](#332-error-handling) as follows:
+HTTP error responses use the [google.rpc.Status](https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto) JSON representation, which maps to the generic A2A error model defined in [Section 4.3.2](#432-error-handling) as follows:
 
 - **Error Code**: Mapped to the HTTP status code and the `error.code` field
 - **Error Message**: Mapped to the `error.message` field (human-readable string)
@@ -2957,7 +2957,7 @@ Content-Type: application/json
 { /* SendMessageRequest object */ }
 ```
 
-**Referenced Objects:** [`SendMessageRequest`](#321-sendmessagerequest)
+**Referenced Objects:** [`SendMessageRequest`](#421-sendmessagerequest)
 
 **Response:**
 
@@ -2970,7 +2970,7 @@ data: { /* StreamResponse object */ }
 data: { /* StreamResponse object */ }
 ```
 
-**Referenced Objects:** [`StreamResponse`](#323-stream-response)
+**Referenced Objects:** [`StreamResponse`](#423-stream-response)
 Streaming responses are simple, linearly ordered sequences: first a `Task` (or single `Message`), then zero or more status or artifact update events until the task reaches a terminal or interrupted state, at which point the stream closes. Implementations SHOULD avoid re-ordering events and MAY optionally resend a final `Task` snapshot before closing.
 
 ## 12. Custom Binding Guidelines
@@ -2981,8 +2981,8 @@ While the A2A protocol provides three standard bindings (JSON-RPC, gRPC, and HTT
 
 Custom protocol bindings **MUST**:
 
-1. **Implement All Core Operations**: Support all operations defined in [Section 3 (A2A Protocol Operations)](#3-a2a-protocol-operations)
-2. **Preserve Data Model**: Use data structures functionally equivalent to those defined in [Section 4 (Protocol Data Model)](#4-protocol-data-model)
+1. **Implement All Core Operations**: Support all operations defined in [Section 4 (A2A Protocol Operations)](#4-a2a-protocol-operations)
+2. **Preserve Data Model**: Use data structures functionally equivalent to those defined in [Section 3 (Protocol Data Model)](#3-protocol-data-model)
 3. **Maintain Semantics**: Ensure operations behave consistently with the abstract operation definitions
 4. **Document Completely**: Provide comprehensive documentation of the binding specification
 
@@ -2997,7 +2997,7 @@ Custom bindings **MUST** provide clear mappings for:
 
 ### 12.3. Service Parameter Transmission
 
-As specified in [Section 3.2.6 (Service Parameters)](#326-service-parameters), custom protocol bindings **MUST** document how service parameters are transmitted. The binding specification **MUST** address:
+As specified in [Section 4.2.6 (Service Parameters)](#426-service-parameters), custom protocol bindings **MUST** document how service parameters are transmitted. The binding specification **MUST** address:
 
 1. **Transmission Mechanism**: The protocol-specific method for transmitting service parameter key-value pairs
 2. **Value Constraints**: Any limitations on service parameter values (e.g., character encoding, size limits)
@@ -3013,7 +3013,7 @@ As specified in [Section 3.2.6 (Service Parameters)](#326-service-parameters), c
 
 Custom bindings **MUST**:
 
-1. **Map Standard Errors**: Provide mappings for all A2A-specific error types defined in [Section 3.2.2 (Error Handling)](#332-error-handling)
+1. **Map Standard Errors**: Provide mappings for all A2A-specific error types defined in [Section 4.2.2 (Error Handling)](#432-error-handling)
 2. **Preserve Error Information**: Ensure error details are accessible to clients
 3. **Use Appropriate Codes**: Map to protocol-native error codes where applicable
 4. **Document Error Format**: Specify the structure of error responses
@@ -3077,7 +3077,7 @@ Implementations **MUST** ensure appropriate scope limitation based on the authen
 
 **Authorization Principles:**
 
-- Servers **MUST** implement authorization checks on every [A2A Protocol Operations](#3-a2a-protocol-operations) request
+- Servers **MUST** implement authorization checks on every [A2A Protocol Operations](#4-a2a-protocol-operations) request
 - Implementations **MUST** scope results to the caller's authorized access boundaries as defined by the agent's authorization model
 - Even when `contextId` or other filter parameters are not specified in requests, implementations **MUST** scope results to the caller's authorized access boundaries
 - Authorization models are agent-defined and **MAY** be based on:
@@ -3089,8 +3089,8 @@ Implementations **MUST** ensure appropriate scope limitation based on the authen
 
 **Operations Requiring Scope Limitation:**
 
-- [`List Tasks`](#314-list-tasks): **MUST** only return tasks visible to the authenticated client according to the agent's authorization model
-- [`Get Task`](#313-get-task): **MUST** verify the authenticated client has access to the requested task according to the agent's authorization model
+- [`List Tasks`](#414-list-tasks): **MUST** only return tasks visible to the authenticated client according to the agent's authorization model
+- [`Get Task`](#413-get-task): **MUST** verify the authenticated client has access to the requested task according to the agent's authorization model
 - Task-related operations (Cancel, Subscribe, Push Notification Config): **MUST** verify the client has appropriate access rights according to the agent's authorization model
 
 **Implementation Requirements:**
@@ -3099,7 +3099,7 @@ Implementations **MUST** ensure appropriate scope limitation based on the authen
 - Authorization checks **MUST** occur before any database queries or operations that could leak information about the existence of resources outside the caller's authorization scope
 - Agents **SHOULD** document their authorization model and access control policies
 
-See also: [Section 3.1.4 List Tasks (Security Note)](#314-list-tasks) for operation-specific requirements.
+See also: [Section 4.1.4 List Tasks (Security Note)](#414-list-tasks) for operation-specific requirements.
 
 ### 13.2. Push Notification Security
 
@@ -3107,7 +3107,7 @@ When implementing push notifications, both agents (as webhook callers) and clien
 
 **Agent (Webhook Caller) Requirements:**
 
-- Agents **MUST** include authentication credentials in webhook requests as specified in [`PushNotificationConfig.authentication`](#432-authenticationinfo)
+- Agents **MUST** include authentication credentials in webhook requests as specified in [`PushNotificationConfig.authentication`](#332-authenticationinfo)
 - Agents **SHOULD** implement reasonable timeout values for webhook requests (recommended: 10-30 seconds)
 - Agents **SHOULD** implement retry logic with exponential backoff for failed deliveries
 - Agents **MAY** stop attempting delivery after a configured number of consecutive failures
@@ -3128,11 +3128,11 @@ When implementing push notifications, both agents (as webhook callers) and clien
 **Configuration Security:**
 
 - Webhook URLs **SHOULD** use HTTPS to protect payload confidentiality in transit
-- Authentication tokens in [`PushNotificationConfig`](#431-pushnotificationconfig) **SHOULD** be treated as secrets and rotated periodically
+- Authentication tokens in [`PushNotificationConfig`](#331-pushnotificationconfig) **SHOULD** be treated as secrets and rotated periodically
 - Agents **SHOULD** securely store push notification configurations and credentials
 - Clients **SHOULD** use unique, single-purpose tokens for each push notification configuration
 
-See also: [Section 4.3 Push Notification Objects](#43-push-notification-objects) and [Section 4.3.3 Push Notification Payload](#433-push-notification-payload).
+See also: [Section 3.3 Push Notification Objects](#33-push-notification-objects) and [Section 3.3.3 Push Notification Payload](#333-push-notification-payload).
 
 ### 13.3. Extended Agent Card Access Control
 
@@ -3140,7 +3140,7 @@ The extended Agent Card feature allows agents to provide additional capabilities
 
 **Access Control Requirements:**
 
-- The [`Get Extended Agent Card`](#3111-get-extended-agent-card) operation **MUST** require authentication
+- The [`Get Extended Agent Card`](#4111-get-extended-agent-card) operation **MUST** require authentication
 - Agents **MUST** authenticate requests using one of the schemes declared in the public `AgentCard.securitySchemes` and `AgentCard.security` fields
 - Agents **MAY** return different extended card content based on the authenticated client's identity or authorization level
 - Agents **SHOULD** implement appropriate caching headers to control client-side caching of extended cards
@@ -3162,10 +3162,10 @@ The extended Agent Card feature allows agents to provide additional capabilities
 **Availability Declaration:**
 
 - Agents declare extended card support via `AgentCard.capabilities.extendedAgentCard`
-- When `capabilities.extendedAgentCard` is `false` or not present, the operation **MUST** return [`UnsupportedOperationError`](#332-error-handling)
-- When support is declared but no extended card is configured, the operation **MUST** return [`ExtendedAgentCardNotConfiguredError`](#332-error-handling)
+- When `capabilities.extendedAgentCard` is `false` or not present, the operation **MUST** return [`UnsupportedOperationError`](#432-error-handling)
+- When support is declared but no extended card is configured, the operation **MUST** return [`ExtendedAgentCardNotConfiguredError`](#432-error-handling)
 
-See also: [Section 3.1.11 Get Extended Agent Card](#3111-get-extended-agent-card) and [Section 3.3.4 Capability Validation](#334-capability-validation).
+See also: [Section 4.1.11 Get Extended Agent Card](#4111-get-extended-agent-card) and [Section 4.3.4 Capability Validation](#434-capability-validation).
 
 ### 13.4. General Security Best Practices
 
@@ -3280,7 +3280,7 @@ A2A Protocol Working Group, <a2a-protocol@example.org>
 
 ### 14.2. HTTP Header Field Registrations
 
-**Note:** The following HTTP headers represent the HTTP-based protocol binding implementation of the abstract A2A service parameters defined in [Section 3.2.6](#326-service-parameters). These registrations are specific to HTTP/HTTPS transports.
+**Note:** The following HTTP headers represent the HTTP-based protocol binding implementation of the abstract A2A service parameters defined in [Section 4.2.6](#426-service-parameters). These registrations are specific to HTTP/HTTPS transports.
 
 #### 14.2.1. A2A-Version Header
 
@@ -3292,7 +3292,7 @@ A2A Protocol Working Group, <a2a-protocol@example.org>
 
 **Author/Change controller:** A2A Protocol Working Group
 
-**Specification document:** Section 3.2.5 of the A2A Protocol Specification
+**Specification document:** Section 4.2.5 of the A2A Protocol Specification
 
 **Related information:**
 The A2A-Version header field indicates the A2A protocol version that the client is using. The value MUST be in the format `Major.Minor` (e.g., "0.3"). If the version is not supported by the agent, the agent returns a `VersionNotSupportedError`.
@@ -3313,7 +3313,7 @@ A2A-Version: 0.3
 
 **Author/Change controller:** A2A Protocol Working Group
 
-**Specification document:** Section 3.2.5 of the A2A Protocol Specification
+**Specification document:** Section 4.2.5 of the A2A Protocol Specification
 
 **Related information:**
 The A2A-Extensions header field contains a comma-separated list of extension URIs that the client wants to use for the request. Extensions allow agents to provide additional functionality beyond the core A2A specification while maintaining backward compatibility.
@@ -3333,7 +3333,7 @@ A2A-Extensions: https://example.com/extensions/geolocation/v1,https://standards.
 **Specification document:** Section 8.2 of the A2A Protocol Specification
 
 **Related information:**
-The `.well-known/agent-card.json` URI provides a standardized location for discovering an A2A agent's capabilities, supported protocols, authentication requirements, and available skills. The resource at this URI MUST return an AgentCard object as defined in Section 4.4.1 of the A2A specification.
+The `.well-known/agent-card.json` URI provides a standardized location for discovering an A2A agent's capabilities, supported protocols, authentication requirements, and available skills. The resource at this URI MUST return an AgentCard object as defined in [Section 3.4.1](#341-agentcard) of the A2A specification.
 
 **Status:** Permanent
 
@@ -3341,9 +3341,9 @@ The `.well-known/agent-card.json` URI provides a standardized location for disco
 
 - The Agent Card MAY contain public information about an agent's capabilities and SHOULD NOT include sensitive credentials or internal implementation details
 - Implementations SHOULD support HTTPS to ensure authenticity and integrity of the Agent Card
-- Agent Cards MAY be signed using JSON Web Signatures (JWS) as specified in the AgentCardSignature object (Section 4.4.7)
+- Agent Cards MAY be signed using JSON Web Signatures (JWS) as specified in the AgentCardSignature object ([Section 3.4.7](#347-agentcardsignature))
 - Clients SHOULD verify signatures when present to ensure the Agent Card has not been tampered with
-- Extended Agent Cards retrieved via authenticated endpoints (Section 3.1.11) MAY contain additional information and MUST enforce appropriate access controls
+- Extended Agent Cards retrieved via authenticated endpoints ((Section 4.1.11)[#4111-get-extended-agent-card]) MAY contain additional information and MUST enforce appropriate access controls
 
 **Example:**
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -144,702 +144,83 @@ A2A revolves around several key concepts. For detailed explanations, please refe
 - **Context:** An optional identifier to logically group related tasks and messages.
 - **Extension:** A mechanism for agents to provide additional functionality or data beyond the core A2A specification.
 
-## 3. A2A Protocol Operations
-
-This section describes the core operations of the A2A protocol in a binding-independent manner. These operations define the fundamental capabilities that all A2A implementations must support, regardless of the underlying binding mechanism.
-
-### 3.1. Core Operations
-
-The following operations define the fundamental capabilities that all A2A implementations must support, independent of the specific protocol binding used. For a quick reference mapping of these operations to protocol-specific method names and endpoints, see [Section 5.3 (Method Mapping Reference)](#53-method-mapping-reference). For detailed protocol-specific implementation details, see:
-
-- [Section 9: JSON-RPC Protocol Binding](#9-json-rpc-protocol-binding)
-- [Section 10: gRPC Protocol Binding](#10-grpc-protocol-binding)
-- [Section 11: HTTP+JSON/REST Protocol Binding](#11-httpjsonrest-protocol-binding)
-
-#### 3.1.1. Send Message
-
-The primary operation for initiating agent interactions. Clients send a message to an agent and receive either a task that tracks the processing or a direct response message.
-
-**Inputs:**
-
-- [`SendMessageRequest`](#321-sendmessagerequest): Request object containing the message, configuration, and metadata
-
-**Outputs:**
-
-- [`Task`](#411-task): A task object representing the processing of the message, OR
-- [`Message`](#414-message): A direct response message (for simple interactions that don't require task tracking)
-
-**Errors:**
-
-- [`ContentTypeNotSupportedError`](#332-error-handling): A Media Type provided in the request's message parts is not supported by the agent.
-- [`UnsupportedOperationError`](#332-error-handling): Messages sent to Tasks that are in a terminal state (e.g., completed, canceled, rejected) cannot accept further messages.
-- [`TaskNotFoundError`](#332-error-handling): The task ID does not exist or is not accessible.
-
-**Behavior:**
-
-The agent MAY create a new `Task` to process the provided message asynchronously or MAY return a direct `Message` response for simple interactions. The operation MUST return immediately with either task information or response message. Task processing MAY continue asynchronously after the response when a [`Task`](#411-task) is returned.
-
-#### 3.1.2. Send Streaming Message
-
-Similar to Send Message but with real-time streaming of updates during processing.
-
-**Inputs:**
-
-- [`SendMessageRequest`](#321-sendmessagerequest): Request object containing the message, configuration, and metadata
-
-**Outputs:**
-
-- [`Stream Response`](#323-stream-response) object containing:
-    - Initial response: [`Task`](#411-task) object OR [`Message`](#414-message) object
-    - Subsequent events following a `Task` MAY include stream of [`TaskStatusUpdateEvent`](#421-taskstatusupdateevent) and [`TaskArtifactUpdateEvent`](#422-taskartifactupdateevent) objects
-- Final completion indicator
-
-**Errors:**
-
-- [`UnsupportedOperationError`](#332-error-handling): Streaming is not supported by the agent (see [Capability Validation](#334-capability-validation)).
-- [`UnsupportedOperationError`](#332-error-handling): Messages sent to Tasks that are in a terminal state (e.g., completed, canceled, rejected) cannot accept further messages.
-- [`ContentTypeNotSupportedError`](#332-error-handling): A Media Type provided in the request's message parts is not supported by the agent.
-- [`TaskNotFoundError`](#332-error-handling): The task ID does not exist or is not accessible.
-
-**Behavior:**
-
-The operation MUST establish a streaming connection for real-time updates. The stream MUST follow one of these patterns:
-
-1. **Message-only stream:** If the agent returns a [`Message`](#414-message), the stream MUST contain exactly one `Message` object and then close immediately. No task tracking or updates are provided.
-
-2. **Task lifecycle stream:** If the agent returns a [`Task`](#411-task), the stream MUST begin with the Task object, followed by zero or more [`TaskStatusUpdateEvent`](#421-taskstatusupdateevent) or [`TaskArtifactUpdateEvent`](#422-taskartifactupdateevent) objects. The stream MUST close when the task reaches a terminal state (e.g. completed, failed, canceled, rejected).
-
-The agent MAY return a `Task` for complex processing with status/artifact updates or MAY return a `Message` for direct streaming responses without task overhead. The implementation MUST provide immediate feedback on progress and intermediate results.
-
-#### 3.1.3. Get Task
-
-Retrieves the current state (including status, artifacts, and optionally history) of a previously initiated task. This is typically used for polling the status of a task initiated with message/send, or for fetching the final state of a task after being notified via a push notification or after a stream has ended.
-
-**Inputs:**
-
-{{ proto_to_table("GetTaskRequest") }}
-
-See [History Length Semantics](#324-history-length-semantics) for details about `historyLength`.
-
-**Outputs:**
-
-- [`Task`](#411-task): Current state and artifacts of the requested task
-
-**Errors:**
-
-- [`TaskNotFoundError`](#332-error-handling): The task ID does not exist or is not accessible.
-
-#### 3.1.4. List Tasks
-
-Retrieves a list of tasks with optional filtering and pagination capabilities. This method allows clients to discover and manage multiple tasks across different contexts or with specific status criteria.
-
-**Inputs:**
-
-{{ proto_to_table("ListTasksRequest") }}
-
-When `includeArtifacts` is false (the default), the artifacts field MUST be omitted entirely from each Task object in the response. The field should not be present as an empty array or null value. When `includeArtifacts` is true, the artifacts field should be included with its actual content (which may be an empty array if the task has no artifacts).
-
-**Outputs:**
-
-{{ proto_to_table("ListTasksResponse") }}
-
-Note on `nextPageToken`: The `nextPageToken` field MUST always be present in the response. When there are no more results to retrieve (i.e., this is the final page), the field MUST be set to an empty string (""). Clients should check for an empty string to determine if more pages are available.
-
-**Errors:**
-
-None specific to this operation beyond standard protocol errors.
-
-**Behavior:**
-
-The operation MUST return only tasks visible to the authenticated client and MUST use cursor-based pagination for performance and consistency. Tasks MUST be sorted by last update time in descending order. Implementations MUST implement appropriate authorization scoping to ensure clients can only access authorized tasks. See [Section 13.1 Data Access and Authorization Scoping](#131-data-access-and-authorization-scoping) for detailed security requirements.
-
-***Pagination Strategy:***
-
-This method uses cursor-based pagination (via `pageToken`/`nextPageToken`) rather than offset-based pagination for better performance and consistency, especially with large datasets. Cursor-based pagination avoids the "deep pagination problem" where skipping large numbers of records becomes inefficient for databases. This approach is consistent with the gRPC specification, which also uses cursor-based pagination (page_token/next_page_token).
-
-***Ordering:***
-
-Implementations MUST return tasks sorted by their status timestamp time in descending order (most recently updated tasks first). This ensures consistent pagination and allows clients to efficiently monitor recent task activity.
-
-#### 3.1.5. Cancel Task
-
-Requests the cancellation of an ongoing task. The server will attempt to cancel the task, but success is not guaranteed (e.g., the task might have already completed or failed, or cancellation might not be supported at its current stage).
-
-**Inputs:**
-
-{{ proto_to_table("CancelTaskRequest") }}
-
-**Outputs:**
-
-- Updated [`Task`](#411-task) with cancellation status
-
-**Errors:**
-
-- [`TaskNotCancelableError`](#332-error-handling): The task is not in a cancelable state (e.g., already completed, failed, or canceled).
-- [`TaskNotFoundError`](#332-error-handling): The task ID does not exist or is not accessible.
-
-**Behavior:**
-
-The operation attempts to cancel the specified task and returns its updated state.
-
-#### 3.1.6. Subscribe to Task
-
-<span id="79-taskssubscribe"></span>
-
-Establishes a streaming connection to receive updates for an existing task.
-
-**Inputs:**
-
-{{ proto_to_table("SubscribeToTaskRequest") }}
-
-**Outputs:**
-
-- [`Stream Response`](#323-stream-response) object containing:
-    - Initial response: [`Task`](#411-task) object with current state
-    - Stream of [`TaskStatusUpdateEvent`](#421-taskstatusupdateevent) and [`TaskArtifactUpdateEvent`](#422-taskartifactupdateevent) objects
-
-**Errors:**
-
-- [`UnsupportedOperationError`](#332-error-handling): Streaming is not supported by the agent (see [Capability Validation](#334-capability-validation)).
-- [`TaskNotFoundError`](#332-error-handling): The task ID does not exist or is not accessible.
-- [`UnsupportedOperationError`](#332-error-handling): The operation is attempted on a task that is in a terminal state (`completed`, `failed`, `canceled`, or `rejected`).
-
-**Behavior:**
-
-The operation enables real-time monitoring of task progress and can be used with any task that is not in a terminal state. The stream MUST terminate when the task reaches a terminal state (`completed`, `failed`, `canceled`, or `rejected`).
-
-The operation MUST return a `Task` object as the first event in the stream, representing the current state of the task at the time of subscription. This prevents a potential loss of information between a call to `GetTask` and calling `SubscribeToTask`.
-
-#### 3.1.7. Create Push Notification Config
-
-<span id="75-taskspushnotificationconfigset"></span>
-<span id="317-create-push-notification-config"></span>
-
-Creates a push notification configuration for a task to receive asynchronous updates via webhook.
-
-**Inputs:**
-
-{{ proto_to_table("CreateTaskPushNotificationConfigRequest") }}
-
-**Outputs:**
-
-- [`PushNotificationConfig`](#431-pushnotificationconfig): Created configuration with assigned ID
-
-**Errors:**
-
-- [`PushNotificationNotSupportedError`](#332-error-handling): Push notifications are not supported by the agent (see [Capability Validation](#334-capability-validation)).
-- [`TaskNotFoundError`](#332-error-handling): The task ID does not exist or is not accessible.
-
-**Behavior:**
-
-The operation MUST establish a webhook endpoint for task update notifications. When task updates occur, the agent will send HTTP POST requests to the configured webhook URL with [`StreamResponse`](#323-stream-response) payloads (see [Push Notification Payload](#433-push-notification-payload) for details). This operation is only available if the agent supports push notifications capability. The configuration MUST persist until task completion or explicit deletion.
-
- <span id="tasks-push-notification-config-operations"></span><span id="grpc-push-notification-operations"></span><span id="push-notification-operations"></span>
-
-#### 3.1.8. Get Push Notification Config
-
-<span id="76-taskspushnotificationconfigget"></span>
-
-Retrieves an existing push notification configuration for a task.
-
-**Inputs:**
-
-{{ proto_to_table("GetTaskPushNotificationConfigRequest") }}
-
-**Outputs:**
-
-- [`PushNotificationConfig`](#431-pushnotificationconfig): The requested configuration
-
-**Errors:**
-
-- [`PushNotificationNotSupportedError`](#332-error-handling): Push notifications are not supported by the agent (see [Capability Validation](#334-capability-validation)).
-- [`TaskNotFoundError`](#332-error-handling): The push notification configuration does not exist.
-
-**Behavior:**
-
-The operation MUST return configuration details including webhook URL and notification settings. The operation MUST fail if the configuration does not exist or the client lacks access.
-
-#### 3.1.9. List Push Notification Configs
-
-Retrieves all push notification configurations for a task.
-
-**Inputs:**
-
-{{ proto_to_table("ListTaskPushNotificationConfigsRequest") }}
-
-**Outputs:**
-
-{{ proto_to_table("ListTaskPushNotificationConfigsResponse") }}
-
-**Errors:**
-
-- [`PushNotificationNotSupportedError`](#332-error-handling): Push notifications are not supported by the agent (see [Capability Validation](#334-capability-validation)).
-- [`TaskNotFoundError`](#332-error-handling): The task ID does not exist or is not accessible.
-
-**Behavior:**
-
-The operation MUST return all active push notification configurations for the specified task and MAY support pagination for tasks with many configurations.
-
-#### 3.1.10. Delete Push Notification Config
-
-Removes a push notification configuration for a task.
-
-**Inputs:**
-
-{{ proto_to_table("DeleteTaskPushNotificationConfigRequest") }}
-
-**Outputs:**
-
-- Confirmation of deletion (implementation-specific)
-
-**Errors:**
-
-- [`PushNotificationNotSupportedError`](#332-error-handling): Push notifications are not supported by the agent (see [Capability Validation](#334-capability-validation)).
-- [`TaskNotFoundError`](#332-error-handling): The task ID does not exist.
-
-**Behavior:**
-
-The operation MUST permanently remove the specified push notification configuration. No further notifications will be sent to the configured webhook after deletion. This operation MUST be idempotent - multiple deletions of the same config have the same effect.
-
-#### 3.1.11. Get Extended Agent Card
-
-Retrieves a potentially more detailed version of the Agent Card after the client has authenticated. This endpoint is available only if `AgentCard.capabilities.extendedAgentCard` is `true`.
-
-**Inputs:**
-
-{{ proto_to_table("GetExtendedAgentCardRequest") }}
-
-**Outputs:**
-
-- [`AgentCard`](#441-agentcard): A complete Agent Card object, which may contain additional details or skills not present in the public card
-
-**Errors:**
-
-- [`UnsupportedOperationError`](#332-error-handling): The agent does not support authenticated extended cards (see [Capability Validation](#334-capability-validation)).
-- [`ExtendedAgentCardNotConfiguredError`](#332-error-handling): The agent declares support but does not have an extended agent card configured.
-
-**Behavior:**
-
-- **Authentication**: The client MUST authenticate the request using one of the schemes declared in the public `AgentCard.securitySchemes` and `AgentCard.security` fields.
-- **Extended Information**: The operation MAY return different details based on client authentication level, including additional skills, capabilities, or configuration not available in the public Agent Card.
-- **Card Replacement**: Clients retrieving this extended card SHOULD replace their cached public Agent Card with the content received from this endpoint for the duration of their authenticated session or until the card's version changes.
-- **Availability**: This operation is only available if the public Agent Card declares `capabilities.extendedAgentCard: true`.
-
-For detailed security guidance on extended agent cards, see [Section 13.3 Extended Agent Card Access Control](#133-extended-agent-card-access-control).
-
-### 3.2. Operation Parameter Objects
-
-This section defines common parameter objects used across multiple operations.
-
-#### 3.2.1. SendMessageRequest
-
-{{ proto_to_table("SendMessageRequest") }}
-
-#### 3.2.2. SendMessageConfiguration
-
-{{ proto_to_table("SendMessageConfiguration") }}
-
-**Execution Mode:**
-
-The `return_immediately` field in [`SendMessageConfiguration`](#322-sendmessageconfiguration) controls whether the operation returns immediately or waits for task completion. Operations are blocking by default:
-
-- **Blocking (`return_immediately: false` or unset)**: The operation MUST wait until the task reaches a terminal state (`COMPLETED`, `FAILED`, `CANCELED`, `REJECTED`) or an interrupted state (`INPUT_REQUIRED`, `AUTH_REQUIRED`) before returning. The response MUST include the latest task state with all artifacts and status information. This is the default behavior.
-
-- **Non-Blocking (`return_immediately: true`)**: The operation MUST return immediately after creating the task, even if processing is still in progress. The returned task will have an in-progress state (e.g., `working`, `input_required`). It is the caller's responsibility to poll for updates using [Get Task](#313-get-task), subscribe via [Subscribe to Task](#316-subscribe-to-task), or receive updates via push notifications.
-
-The `return_immediately` field has no effect:
-
-- when the operation returns a direct [`Message`](#414-message) response instead of a task.
-- for streaming operations, which always return updates in real-time.
-- on configured push notification configurations, which operates independently of execution mode.
-
-#### 3.2.3. Stream Response
-
-<span id="323-stream-response"></span>
-<span id="72-messagestream"></span>
-
-{{ proto_to_table("StreamResponse") }}
-
-This wrapper allows streaming endpoints to return different types of updates through a single response stream while maintaining type safety.
-
-#### 3.2.4. History Length Semantics
-
-The `historyLength` parameter appears in multiple operations and controls how much task history is returned in responses. This parameter follows consistent semantics across all operations:
-
-- **Unset/undefined**: No limit imposed; server returns its default amount of history (implementation-defined, may be all history)
-- **0**: No history should be returned; the `history` field SHOULD be omitted
-- **> 0**: Return at most this many recent messages from the task's history
-
-#### 3.2.5. Metadata
-
-A flexible key-value map for passing additional context or parameters with operations. Metadata keys and are strings and values can be any valid value that can be represented in JSON. [`Extensions`](#46-extensions) can be used to strongly type metadata values for specific use cases.
-
-#### 3.2.6 Service Parameters
-
-A key-value map for passing horizontally applicable context or parameters with case-insensitive string keys and case-sensitive string values. The transmission mechanism for these service parameter key-value pairs is defined by the specific protocol binding (e.g., HTTP headers for HTTP-based bindings, gRPC metadata for gRPC bindings). Custom protocol bindings **MUST** specify how service parameters are transmitted in their binding specification.
-
-**Standard A2A Service Parameters:**
-
-| Name             | Description                                                                                                                                             | Example Value                                                                                 |
-| :--------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------ | :-------------------------------------------------------------------------------------------- |
-| `A2A-Extensions` | Comma-separated list of extension URIs that the client wants to use for the request                                                                     | `https://example.com/extensions/geolocation/v1,https://standards.org/extensions/citations/v1` |
-| `A2A-Version`    | The A2A protocol version that the client is using. If the version is not supported, the agent returns [`VersionNotSupportedError`](#332-error-handling) | `0.3`                                                                                         |
-
-As service parameter names MAY need to co-exist with other parameters defined by the underlying transport protocol or infrastructure, all service parameters defined by this specification will be prefixed with `a2a-`.
-
-### 3.3. Operation Semantics
-
-#### 3.3.1. Idempotency
-
-- **Get operations** (Get Task, List Tasks, Get Extended Agent Card) are naturally idempotent
-- **Send Message** operations MAY be idempotent. Agents may utilize the messageId to detect duplicate messages.
-- **Cancel Task** operations are idempotent - multiple cancellation requests have the same effect. A duplicate cancellation request MAY return `TaskNotFoundError` if the task has already been canceled and purged.
-
-#### 3.3.2. Error Handling
-
-All operations may return errors in the following categories. Servers **MUST** return appropriate errors and **SHOULD** provide actionable information to help clients resolve issues.
-
-**Error Categories and Server Requirements:**
-
-- **Authentication Errors**: Invalid or missing credentials
-    - Servers **MUST** reject requests with invalid or missing authentication credentials
-    - Servers **SHOULD** include authentication challenge information in the error response
-    - Servers **SHOULD** specify which authentication scheme is required
-    - Example error codes: HTTP `401 Unauthorized`, gRPC `UNAUTHENTICATED`, JSON-RPC custom error
-    - Example scenarios: Missing bearer token, expired API key, invalid OAuth token
-
-- **Authorization Errors**: Insufficient permissions for requested operation
-    - Servers **MUST** return an authorization error when the authenticated client lacks required permissions
-    - Servers **SHOULD** indicate what permission or scope is missing (without leaking sensitive information about resources the client cannot access)
-    - Servers **MUST NOT** reveal the existence of resources the client is not authorized to access
-    - Example error codes: HTTP `403 Forbidden`, gRPC `PERMISSION_DENIED`, JSON-RPC custom error
-    - Example scenarios: Attempting to access a task created by another user, insufficient OAuth scopes
-
-- **Validation Errors**: Invalid input parameters or message format
-    - Servers **MUST** validate all input parameters before processing
-    - Servers **SHOULD** specify which parameter(s) failed validation and why
-    - Servers **SHOULD** provide guidance on valid parameter values or formats
-    - Example error codes: HTTP `400 Bad Request`, gRPC `INVALID_ARGUMENT`, JSON-RPC `-32602 Invalid params`
-    - Example scenarios: Invalid task ID format, missing required message parts, unsupported content type
-
-- **Resource Errors**: Requested task not found or not accessible
-    - Servers **MUST** return a not found error when a requested resource does not exist or is not accessible to the authenticated client
-    - Servers **SHOULD NOT** distinguish between "does not exist" and "not authorized" to prevent information leakage
-    - Example error codes: HTTP `404 Not Found`, gRPC `NOT_FOUND`, JSON-RPC custom error (see A2A-specific errors)
-    - Example scenarios: Task ID does not exist, task has been deleted, configuration not found
-
-- **System Errors**: Internal agent failures or temporary unavailability
-    - Servers **SHOULD** return appropriate error codes for temporary failures vs. permanent errors
-    - Servers **MAY** include retry guidance (e.g., Retry-After header in HTTP)
-    - Servers **SHOULD** log system errors for diagnostic purposes
-    - Example error codes: HTTP `500 Internal Server Error` or `503 Service Unavailable`, gRPC `INTERNAL` or `UNAVAILABLE`, JSON-RPC `-32603 Internal error`
-    - Example scenarios: Database connection failure, downstream service timeout, rate limit exceeded
-
-**Error Payload Structure:**
-
-All error responses in the A2A protocol, regardless of binding, **MUST** convey the following information:
-
-1. **Error Code**: A machine-readable identifier for the error type (e.g., string code, numeric code, or protocol-specific status)
-2. **Error Message**: A human-readable description of the error
-3. **Error Details** (optional): An array of objects providing additional structured information about the error. Each object in the array **MUST** include a `@type` key that identifies the object's type (using [ProtoJSON `Any` representation](https://protobuf.dev/programming-guides/json)). Well-known types from the [`google.rpc` error model](https://cloud.google.com/apis/design/errors#error_model) (e.g., `ErrorInfo`, `BadRequest`) **SHOULD** be used where applicable. Error details may be used for:
-    - Affected fields or parameters
-    - Contextual information (e.g., task ID, timestamp)
-    - Suggestions for resolution
-
-Protocol bindings **MUST** map these elements to their native error representations while preserving semantic meaning. See binding-specific sections for concrete error format examples: [JSON-RPC Error Handling](#95-error-handling), [gRPC Error Handling](#106-error-handling), and [HTTP/REST Error Handling](#116-error-handling).
-
-**A2A-Specific Errors:**
-
-| Error Name                            | Description                                                                                                                                                       |
-| :------------------------------------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `TaskNotFoundError`                   | The specified task ID does not correspond to an existing or accessible task. It might be invalid, expired, or already completed and purged.                       |
-| `TaskNotCancelableError`              | An attempt was made to cancel a task that is not in a cancelable state (e.g., it has already reached a terminal state like `completed`, `failed`, or `canceled`). |
-| `PushNotificationNotSupportedError`   | Client attempted to use push notification features but the server agent does not support them (i.e., `AgentCard.capabilities.pushNotifications` is `false`).      |
-| `UnsupportedOperationError`           | The requested operation or a specific aspect of it is not supported by this server agent implementation.                                                          |
-| `ContentTypeNotSupportedError`        | A Media Type provided in the request's message parts or implied for an artifact is not supported by the agent or the specific skill being invoked.                |
-| `InvalidAgentResponseError`           | An agent returned a response that does not conform to the specification for the current method.                                                                   |
-| `ExtendedAgentCardNotConfiguredError` | The agent does not have an extended agent card configured when one is required for the requested operation.                                                       |
-| `ExtensionSupportRequiredError`       | Server requested use of an extension marked as `required: true` in the Agent Card but the client did not declare support for it in the request.                   |
-| `VersionNotSupportedError`            | The A2A protocol version specified in the request (via `A2A-Version` service parameter) is not supported by the agent.                                            |
-
-#### 3.3.3. Asynchronous Processing
-
-A2A operations are designed for asynchronous task execution. Operations return immediately with either [`Task`](#411-task) objects or [`Message`](#414-message) objects, and when a Task is returned, processing continues in the background. Clients retrieve task updates through polling, streaming, or push notifications (see [Section 3.5](#35-task-update-delivery-mechanisms)). Agents MAY accept additional messages for tasks in non-terminal states to enable multi-turn interactions (see [Section 3.4](#34-multi-turn-interactions)).
-
-#### 3.3.4. Capability Validation
-
-Agents declare optional capabilities in their [`AgentCard`](#441-agentcard). When clients attempt to use operations or features that require capabilities not declared as supported in the Agent Card, the agent **MUST** return an appropriate error response:
-
-- **Push Notifications**: If `AgentCard.capabilities.pushNotifications` is `false` or not present, operations related to push notification configuration (Create, Get, List, Delete) **MUST** return [`PushNotificationNotSupportedError`](#332-error-handling).
-- **Streaming**: If `AgentCard.capabilities.streaming` is `false` or not present, attempts to use `SendStreamingMessage` or `SubscribeToTask` operations **MUST** return [`UnsupportedOperationError`](#332-error-handling).
-- **Extended Agent Card**: If `AgentCard.capabilities.extendedAgentCard` is `false` or not present, attempts to call the Get Extended Agent Card operation **MUST** return [`UnsupportedOperationError`](#332-error-handling). If the agent declares support but has not configured an extended card, it **MUST** return [`ExtendedAgentCardNotConfiguredError`](#332-error-handling).
-- **Extensions**: When a server requests use of an extension marked as `required: true` in the Agent Card but the client does not declare support for it, the agent **MUST** return [`ExtensionSupportRequiredError`](#332-error-handling).
-
-Clients **SHOULD** validate capability support by examining the Agent Card before attempting operations that require optional capabilities.
-
-### 3.4. Multi-Turn Interactions
-
-The A2A protocol supports multi-turn conversations through context identifiers and task references, enabling agents to maintain conversational continuity across multiple interactions.
-
-#### 3.4.1. Context Identifier Semantics
-
-A `contextId` is an identifier that logically groups multiple related [`Task`](#411-task) and [`Message`](#414-message) objects, providing continuity across a series of interactions.
-
-**Generation and Assignment:**
-
-- Agents **MAY** generate a new `contextId` when processing a [`Message`](#414-message) that does not include a `contextId` field
-- If an agent generates a new `contextId`, it **MUST** be included in the response (either [`Task`](#411-task) or [`Message`](#414-message))
-- Agents **MAY** accept and preserve client-provided `contextId` values
-- If an agent cannot accept a client-provided `contextId`, it **MUST** reject the request with an error and **MUST NOT** generate a new `contextId` for the response
-- Clients **SHOULD NOT** provide a client-generated `contextId` to a server unless they understand how the server will process that `contextId`
-- Server-generated `contextId` values **SHOULD** be treated as opaque identifiers by clients
-
-**Grouping and Scope:**
-
-- A `contextId` logically groups multiple [`Task`](#411-task) objects and [`Message`](#414-message) objects that are part of the same conversational context
-- All tasks and messages with the same `contextId` **SHOULD** be treated as part of the same conversational session
-- Agents **MAY** use the `contextId` to maintain internal state, conversational history, or LLM context across multiple interactions
-- Agents **MAY** implement context expiration or cleanup policies and **SHOULD** document any such policies
-
-#### 3.4.2. Task Identifier Semantics
-
-A `taskId` is a unique identifier for a [`Task`](#411-task) object, representing a stateful unit of work with a defined lifecycle.
-
-**Generation and Assignment:**
-
-- Task IDs are **server-generated** when a new task is created in response to a [`Message`](#414-message)
-- Agents **MUST** generate a unique `taskId` for each new task they create
-- The generated `taskId` **MUST** be included in the [`Task`](#411-task) object returned to the client
-- When a client includes a `taskId` in a [`Message`](#414-message), it **MUST** reference an existing task
-- Agents **MUST** return a [`TaskNotFoundError`](#332-error-handling) if the provided `taskId` does not correspond to an existing task
-- Client-provided `taskId` values for creating new tasks is **NOT** supported
-
-#### 3.4.3. Multi-Turn Conversation Patterns
-
-The A2A protocol supports several patterns for multi-turn interactions:
-
-**Context Continuity:**
-
-- [`Task`](#411-task) objects maintain conversation context through the `contextId` field
-- Clients **MAY** include the `contextId` in subsequent messages to indicate continuation of a previous interaction
-- Clients **MAY** use `taskId` (with or without `contextId`) to continue or refine a specific task
-- Clients **MAY** use `contextId` without `taskId` to start a new task within an existing conversation context
-- Agents **MUST** infer `contextId` from the task if only `taskId` is provided
-- Agents **MUST** reject messages containing mismatching `contextId` and `taskId` (i.e., the provided `contextId` is different from that of the referenced [`Task`](#411-task)).
-
-**Input Required State:**
-
-- Agents can request additional input mid-processing by transitioning a task to the `input-required` state
-- The client continues the interaction by sending a new message with the same `taskId` and `contextId`
-
-**Follow-up Messages:**
-
-- Clients can send additional messages with `taskId` references to continue or refine existing tasks
-- Clients **SHOULD** use the `referenceTaskIds` field in [`Message`](#414-message) to explicitly reference related tasks
-- Agents **SHOULD** use referenced tasks to understand the context and intent of follow-up requests
-
-**Context Inheritance:**
-
-- New tasks created within the same `contextId` can inherit context from previous interactions
-- Agents **SHOULD** leverage the shared `contextId` to provide contextually relevant responses
-
-### 3.5. Task Update Delivery Mechanisms
-
-The A2A protocol provides three complementary mechanisms for clients to receive updates about task progress and completion.
-
-#### 3.5.1. Overview of Update Mechanisms
-
-**Polling (Get Task):**
-
-- Client periodically calls Get Task ([Section 3.1.3](#313-get-task)) to check task status
-- Simple to implement, works with all protocol bindings
-- Higher latency, potential for unnecessary requests
-- Best for: Simple integrations, infrequent updates, clients behind restrictive firewalls
-
-**Streaming:**
-
-- Real-time delivery of events as they occur
-- Operations: Stream Message ([Section 3.1.2](#312-send-streaming-message)) and Subscribe to Task ([Section 3.1.6](#316-subscribe-to-task))
-- Low latency, efficient for frequent updates
-- Requires persistent connection support
-- Best for: Interactive applications, real-time dashboards, live progress monitoring
-- Requires `AgentCard.capabilities.streaming` to be `true`
-
-**Push Notifications (WebHooks):**
-
-- Agent sends HTTP POST requests to client-registered endpoints when task state changes
-- Client does not maintain persistent connection
-- Asynchronous delivery, client must be reachable via HTTP
-- Best for: Server-to-server integrations, long-running tasks, event-driven architectures
-- Operations: Create ([Section 3.1.7](#317-create-push-notification-config)), Get ([Section 3.1.8](#76-taskspushnotificationconfigget)), List ([Section 3.1.9](#319-list-push-notification-configs)), Delete ([Section 3.1.10](#3110-delete-push-notification-config))
-- Event types: TaskStatusUpdateEvent ([Section 4.2.1](#421-taskstatusupdateevent)), TaskArtifactUpdateEvent ([Section 4.2.2](#422-taskartifactupdateevent)), WebHook payloads ([Section 4.3](#43-push-notification-objects))
-- Requires `AgentCard.capabilities.pushNotifications` to be `true`
-- Regardless of the protocol binding being used by the agent, WebHook calls use plain HTTP and the JSON payloads as defined in the HTTP protocol binding
-
-#### 3.5.2. Streaming Event Delivery
-
-**Event Ordering:**
-
-All implementations MUST deliver events in the order they were generated. Events MUST NOT be reordered during transmission, regardless of protocol binding.
-
-**Multiple Streams Per Task:**
-
-An agent MAY serve multiple concurrent streams to one or more clients for the same task. This allows multiple clients (or the same client with multiple connections) to independently subscribe to and receive updates about a task's progress.
-
-When multiple streams are active for a task:
-
-- Events MUST be broadcast to all active streams for that task
-- Each stream MUST receive the same events in the same order
-- Closing one stream MUST NOT affect other active streams for the same task
-- The task lifecycle is independent of any individual stream's lifecycle
-
-This capability enables scenarios such as:
-
-- Multiple team members monitoring the same long-running task
-- A client reconnecting to a task after a network interruption by opening a new stream
-- Different applications or dashboards displaying real-time updates for the same task
-
-#### 3.5.3. Push Notification Delivery
-
-Push notifications are delivered via HTTP POST to client-registered webhook endpoints. The delivery semantics and reliability guarantees are defined in [Section 4.3](#43-push-notification-objects).
-
-### 3.6 Versioning
-
-The specific version of the A2A protocol in use is identified using the `Major.Minor` elements (e.g. `1.0`) of the corresponding A2A specification version. Patch version numbers used by the specification, do not affect protocol compatibility. Patch version numbers SHOULD NOT be used in requests, responses and Agent Cards, and MUST not be considered when clients and servers negotiate protocol versions.
-
-#### 3.6.1 Client Responsibilities
-
-Clients MUST send the `A2A-Version` header with each request to maintain compatibility after an agent upgrades to a new version of the protocol (except for 0.3 Clients - 0.3 will be assumed for empty header). Sending the `A2A-Version` header also provides visibility to agents about version usage in the ecosystem, which can help inform the risks of inplace version upgrades.
-
-**Example of HTTP GET Request with Version Header:**
-
-```http
-GET /tasks/task-123 HTTP/1.1
-Host: agent.example.com
-A2A-Version: 1.0
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
-Accept: application/json
-```
-
-Clients MAY provide the `A2A-Version` as a request parameter instead of a header.
-
-**Example of HTTP GET Request with Version request parameter:**
-
-```http
-GET /tasks/task-123?A2A-Version=1.0 HTTP/1.1
-Host: agent.example.com
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
-Accept: application/json
-```
-
-#### 3.6.2 Server Responsibilities
-
-Agents MUST process requests using the semantics of the requested `A2A-Version` (matching `Major.Minor`). If the version is not supported by the interface, agents MUST return a [`VersionNotSupportedError`](#332-error-handling).
-
-Agents MUST interpret empty value as 0.3 version.
-
-Agents CAN expose multiple interfaces for the same transport with different versions under the same or different URLs.
-
-#### 3.6.3 Tooling support
-
-Tooling libraries and SDKs that implement the A2A protocol MUST provide mechanisms to help clients manage protocol versioning, such as negotiation of the transport and protocol version used. Client Agents that require the latest features of the protocol should be configured to request specific versions and avoid automatic fallback to older versions, to prevent silently losing functionality.
-
-### 3.7 Messages and Artifacts
-
-Messages and Artifacts serve distinct purposes within the A2A protocol. The core interaction model defined by A2A is for clients to send messages to initiate a task that produces one or more artifacts.
-
-Messages play several key roles:
-
-- **Task Initiation**: Clients send Messages to agents to initiate new tasks.
-- **Clarification Messages**: Agents may send Messages back to the client to request clarification prior to initiating a task.
-- **Status Messages**: Agents attach Messages to status update events to inform clients about task progress, request additional input, or provide informational updates.
-- **Task Interaction**: Clients send Messages to provide additional input or instructions for ongoing tasks.
-
-Messages SHOULD NOT be used to deliver task outputs. Results SHOULD BE returned using Artifacts associated with a Task. This separation allows for a clear distinction between communication (Messages) and data output (Artifacts).
-
-The Task History field contains Messages exchanged during task execution. However, not all Messages are guaranteed to be persisted in the Task history; for example, transient informational messages may not be stored. Messages exchanged prior to task creation may not be stored in Task history. The agent is responsible to determine which Messages are persisted in the Task History.
-
-Clients using streaming to retrieve task updates MAY not receive all status update messages if the client is disconnected and then reconnects. Messages MUST NOT be considered a reliable delivery mechanism for critical information.
-
-Agents MAY choose to persist all Messages that contain important information in the Task history to ensure clients can retrieve it later. However, clients MUST NOT rely on this behavior unless negotiated out-of-band.
-
-## 4. Protocol Data Model
+## 3. Protocol Data Model
 
 The A2A protocol defines a canonical data model using Protocol Buffers. All protocol bindings **MUST** provide functionally equivalent representations of these data structures.
 
-### 4.1. Core Objects
+### 3.1. Core Objects
 
 <a id="Task"></a>
 
-#### 4.1.1. Task
+#### 3.1.1. Task
 
 {{ proto_to_table("Task") }}
 
 <a id="TaskStatus"></a>
 
-#### 4.1.2. TaskStatus
+#### 3.1.2. TaskStatus
 
 {{ proto_to_table("TaskStatus") }}
 
 <a id="TaskState"></a>
 
-#### 4.1.3. TaskState
+#### 3.1.3. TaskState
 
 {{ proto_enum_to_table("TaskState") }}
 
 <a id="Message"></a>
 
-#### 4.1.4. Message
+#### 3.1.4. Message
 
 {{ proto_to_table("Message") }}
 
 <a id="Role"></a>
 
-#### 4.1.5. Role
+#### 3.1.5. Role
 
 {{ proto_enum_to_table("Role") }}
 
 <a id="Part"></a>
 
-#### 4.1.6. Part
+#### 3.1.6. Part
 
 {{ proto_to_table("Part") }}
 
 <a id="Artifact"></a>
 
-#### 4.1.7. Artifact
+#### 3.1.7. Artifact
 
 {{ proto_to_table("Artifact") }}
 
-### 4.2. Streaming Events
+### 3.2. Streaming Events
 
 <a id="TaskStatusUpdateEvent"></a>
 
-#### 4.2.1. TaskStatusUpdateEvent
+#### 3.2.1. TaskStatusUpdateEvent
 
 {{ proto_to_table("TaskStatusUpdateEvent") }}
 
 <a id="TaskArtifactUpdateEvent"></a>
 
-#### 4.2.2. TaskArtifactUpdateEvent
+#### 3.2.2. TaskArtifactUpdateEvent
 
 {{ proto_to_table("TaskArtifactUpdateEvent") }}
 
-### 4.3. Push Notification Objects
+### 3.3. Push Notification Objects
 
 <a id="PushNotificationConfig"></a>
 
-#### 4.3.1. PushNotificationConfig
+#### 3.3.1. PushNotificationConfig
 
 {{ proto_to_table("PushNotificationConfig") }}
 
 <a id="PushNotificationAuthenticationInfo"></a>
 
-#### 4.3.2. AuthenticationInfo
+#### 3.3.2. AuthenticationInfo
 
 {{ proto_to_table("AuthenticationInfo") }}
 
-#### 4.3.3. Push Notification Payload
+#### 3.3.3. Push Notification Payload
 
 When a task update occurs, the agent sends an HTTP POST request to the configured webhook URL. The payload uses the same [`StreamResponse`](#323-stream-response) format as streaming operations, allowing push notifications to deliver the same event types as real-time streams.
 
@@ -888,118 +269,118 @@ The agent MUST include authentication credentials in the request headers as spec
 
 For detailed security guidance on push notifications, see [Section 13.2 Push Notification Security](#132-push-notification-security).
 
-### 4.4. Agent Discovery Objects
+### 3.4. Agent Discovery Objects
 
 <a id="AgentCard"></a>
 
-#### 4.4.1. AgentCard
+#### 3.4.1. AgentCard
 
 {{ proto_to_table("AgentCard") }}
 
 <a id="AgentProvider"></a>
 
-#### 4.4.2. AgentProvider
+#### 3.4.2. AgentProvider
 
 {{ proto_to_table("AgentProvider") }}
 
 <a id="AgentCapabilities"></a>
 
-#### 4.4.3. AgentCapabilities
+#### 3.4.3. AgentCapabilities
 
 {{ proto_to_table("AgentCapabilities") }}
 
 <a id="AgentExtension"></a>
 
-#### 4.4.4. AgentExtension
+#### 3.4.4. AgentExtension
 
 {{ proto_to_table("AgentExtension") }}
 
 <a id="AgentSkill"></a>
 
-#### 4.4.5. AgentSkill
+#### 3.4.5. AgentSkill
 
 {{ proto_to_table("AgentSkill") }}
 
 <a id="AgentInterface"></a>
 
-#### 4.4.6. AgentInterface
+#### 3.4.6. AgentInterface
 
 {{ proto_to_table("AgentInterface") }}
 
 <a id="AgentCardSignature"></a>
 
-#### 4.4.7. AgentCardSignature
+#### 3.4.7. AgentCardSignature
 
 {{ proto_to_table("AgentCardSignature") }}
 
-### 4.5. Security Objects
+### 3.5. Security Objects
 
 <a id="Security"></a>
 <a id="SecurityScheme"></a>
 
-#### 4.5.1. SecurityScheme
+#### 3.5.1. SecurityScheme
 
 {{ proto_to_table("SecurityScheme") }}
 
 <a id="APIKeySecurityScheme"></a>
 
-#### 4.5.2. APIKeySecurityScheme
+#### 3.5.2. APIKeySecurityScheme
 
 {{ proto_to_table("APIKeySecurityScheme") }}
 
 <a id="HTTPAuthSecurityScheme"></a>
 
-#### 4.5.3. HTTPAuthSecurityScheme
+#### 3.5.3. HTTPAuthSecurityScheme
 
 {{ proto_to_table("HTTPAuthSecurityScheme") }}
 
 <a id="OAuth2SecurityScheme"></a>
 
-#### 4.5.4. OAuth2SecurityScheme
+#### 3.5.4. OAuth2SecurityScheme
 
 {{ proto_to_table("OAuth2SecurityScheme") }}
 
 <a id="OpenIdConnectSecurityScheme"></a>
 
-#### 4.5.5. OpenIdConnectSecurityScheme
+#### 3.5.5. OpenIdConnectSecurityScheme
 
 {{ proto_to_table("OpenIdConnectSecurityScheme") }}
 
 <a id="MutualTlsSecurityScheme"></a>
 
-#### 4.5.6. MutualTlsSecurityScheme
+#### 3.5.6. MutualTlsSecurityScheme
 
 {{ proto_to_table("MutualTlsSecurityScheme") }}
 
 <a id="OAuthFlows"></a>
 
-#### 4.5.7. OAuthFlows
+#### 3.5.7. OAuthFlows
 
 {{ proto_to_table("OAuthFlows") }}
 
 <a id="AuthorizationCodeOAuthFlow"></a>
 
-#### 4.5.8. AuthorizationCodeOAuthFlow
+#### 3.5.8. AuthorizationCodeOAuthFlow
 
 {{ proto_to_table("AuthorizationCodeOAuthFlow") }}
 
 <a id="ClientCredentialsOAuthFlow"></a>
 
-#### 4.5.9. ClientCredentialsOAuthFlow
+#### 3.5.9. ClientCredentialsOAuthFlow
 
 {{ proto_to_table("ClientCredentialsOAuthFlow") }}
 
 <a id="DeviceCodeOAuthFlow"></a>
 
-#### 4.5.10. DeviceCodeOAuthFlow
+#### 3.5.10. DeviceCodeOAuthFlow
 
 {{ proto_to_table("DeviceCodeOAuthFlow") }}
 
-### 4.6. Extensions
+### 3.6. Extensions
 
 The A2A protocol supports extensions to provide additional functionality or data beyond the core specification while maintaining backward compatibility and interoperability. Extensions allow agents to declare additional capabilities such as protocol enhancements or vendor-specific features, maintain compatibility with clients that don't support specific extensions, enable innovation through experimental or domain-specific features without modifying the core protocol, and facilitate standardization by providing a pathway for community-developed features to become part of the core specification.
 
-#### 4.6.1. Extension Declaration
+#### 3.6.1. Extension Declaration
 
 Agents declare their supported extensions in the [`AgentCard`](#441-agentcard) using the `extensions` field, which contains an array of [`AgentExtension`](#444-agentextension) objects.
 
@@ -1074,7 +455,7 @@ A2A-Extensions: https://example.com/extensions/geolocation/v1,https://standards.
 }
 ```
 
-#### 4.6.2. Extensions Points
+#### 3.6.2. Extensions Points
 
 Extensions can be integrated into the A2A protocol at several well-defined extension points:
 
@@ -1134,12 +515,631 @@ Artifacts can include extension data to provide strongly typed context or metada
 }
 ```
 
-#### 4.6.3. Extension Versioning and Compatibility
+#### 3.6.3. Extension Versioning and Compatibility
 
 Extensions **SHOULD** include version information in their URI identifier. This allows clients and agents to negotiate compatible versions of extensions during interactions. A new URI **MUST** be created for breaking changes to an extension.
 
 If a client requests a versions of an extension that the agent does not support, the agent **SHOULD** ignore the extension for that interaction and proceed without it, unless the extension is marked as `required` in the AgentCard, in which case the agent **MUST** return an error indicating unsupported extension. It **MUST NOT** fall back to a previous version of the extension automatically.
 
+
+## 4. Protocol Operations
+
+This section describes the core operations of the A2A protocol in a binding-independent manner. These operations define the fundamental capabilities that all A2A implementations must support, regardless of the underlying binding mechanism.
+
+### 4.1. Core Operations
+
+The following operations define the fundamental capabilities that all A2A implementations must support, independent of the specific protocol binding used. For a quick reference mapping of these operations to protocol-specific method names and endpoints, see [Section 5.3 (Method Mapping Reference)](#53-method-mapping-reference). For detailed protocol-specific implementation details, see:
+
+- [Section 9: JSON-RPC Protocol Binding](#9-json-rpc-protocol-binding)
+- [Section 10: gRPC Protocol Binding](#10-grpc-protocol-binding)
+- [Section 11: HTTP+JSON/REST Protocol Binding](#11-httpjsonrest-protocol-binding)
+
+#### 4.1.1. Send Message
+
+The primary operation for initiating agent interactions. Clients send a message to an agent and receive either a task that tracks the processing or a direct response message.
+
+**Inputs:**
+
+- [`SendMessageRequest`](#321-sendmessagerequest): Request object containing the message, configuration, and metadata
+
+**Outputs:**
+
+- [`Task`](#411-task): A task object representing the processing of the message, OR
+- [`Message`](#414-message): A direct response message (for simple interactions that don't require task tracking)
+
+**Errors:**
+
+- [`ContentTypeNotSupportedError`](#332-error-handling): A Media Type provided in the request's message parts is not supported by the agent.
+- [`UnsupportedOperationError`](#332-error-handling): Messages sent to Tasks that are in a terminal state (e.g., completed, canceled, rejected) cannot accept further messages.
+- [`TaskNotFoundError`](#332-error-handling): The task ID does not exist or is not accessible.
+
+**Behavior:**
+
+The agent MAY create a new `Task` to process the provided message asynchronously or MAY return a direct `Message` response for simple interactions. The operation MUST return immediately with either task information or response message. Task processing MAY continue asynchronously after the response when a [`Task`](#411-task) is returned.
+
+#### 4.1.2. Send Streaming Message
+
+Similar to Send Message but with real-time streaming of updates during processing.
+
+**Inputs:**
+
+- [`SendMessageRequest`](#321-sendmessagerequest): Request object containing the message, configuration, and metadata
+
+**Outputs:**
+
+- [`Stream Response`](#323-stream-response) object containing:
+    - Initial response: [`Task`](#411-task) object OR [`Message`](#414-message) object
+    - Subsequent events following a `Task` MAY include stream of [`TaskStatusUpdateEvent`](#421-taskstatusupdateevent) and [`TaskArtifactUpdateEvent`](#422-taskartifactupdateevent) objects
+- Final completion indicator
+
+**Errors:**
+
+- [`UnsupportedOperationError`](#332-error-handling): Streaming is not supported by the agent (see [Capability Validation](#334-capability-validation)).
+- [`UnsupportedOperationError`](#332-error-handling): Messages sent to Tasks that are in a terminal state (e.g., completed, canceled, rejected) cannot accept further messages.
+- [`ContentTypeNotSupportedError`](#332-error-handling): A Media Type provided in the request's message parts is not supported by the agent.
+- [`TaskNotFoundError`](#332-error-handling): The task ID does not exist or is not accessible.
+
+**Behavior:**
+
+The operation MUST establish a streaming connection for real-time updates. The stream MUST follow one of these patterns:
+
+1. **Message-only stream:** If the agent returns a [`Message`](#414-message), the stream MUST contain exactly one `Message` object and then close immediately. No task tracking or updates are provided.
+
+2. **Task lifecycle stream:** If the agent returns a [`Task`](#411-task), the stream MUST begin with the Task object, followed by zero or more [`TaskStatusUpdateEvent`](#421-taskstatusupdateevent) or [`TaskArtifactUpdateEvent`](#422-taskartifactupdateevent) objects. The stream MUST close when the task reaches a terminal state (e.g. completed, failed, canceled, rejected).
+
+The agent MAY return a `Task` for complex processing with status/artifact updates or MAY return a `Message` for direct streaming responses without task overhead. The implementation MUST provide immediate feedback on progress and intermediate results.
+
+#### 4.1.3. Get Task
+
+Retrieves the current state (including status, artifacts, and optionally history) of a previously initiated task. This is typically used for polling the status of a task initiated with message/send, or for fetching the final state of a task after being notified via a push notification or after a stream has ended.
+
+**Inputs:**
+
+{{ proto_to_table("GetTaskRequest") }}
+
+See [History Length Semantics](#324-history-length-semantics) for details about `historyLength`.
+
+**Outputs:**
+
+- [`Task`](#411-task): Current state and artifacts of the requested task
+
+**Errors:**
+
+- [`TaskNotFoundError`](#332-error-handling): The task ID does not exist or is not accessible.
+
+#### 4.1.4. List Tasks
+
+Retrieves a list of tasks with optional filtering and pagination capabilities. This method allows clients to discover and manage multiple tasks across different contexts or with specific status criteria.
+
+**Inputs:**
+
+{{ proto_to_table("ListTasksRequest") }}
+
+When `includeArtifacts` is false (the default), the artifacts field MUST be omitted entirely from each Task object in the response. The field should not be present as an empty array or null value. When `includeArtifacts` is true, the artifacts field should be included with its actual content (which may be an empty array if the task has no artifacts).
+
+**Outputs:**
+
+{{ proto_to_table("ListTasksResponse") }}
+
+Note on `nextPageToken`: The `nextPageToken` field MUST always be present in the response. When there are no more results to retrieve (i.e., this is the final page), the field MUST be set to an empty string (""). Clients should check for an empty string to determine if more pages are available.
+
+**Errors:**
+
+None specific to this operation beyond standard protocol errors.
+
+**Behavior:**
+
+The operation MUST return only tasks visible to the authenticated client and MUST use cursor-based pagination for performance and consistency. Tasks MUST be sorted by last update time in descending order. Implementations MUST implement appropriate authorization scoping to ensure clients can only access authorized tasks. See [Section 13.1 Data Access and Authorization Scoping](#131-data-access-and-authorization-scoping) for detailed security requirements.
+
+***Pagination Strategy:***
+
+This method uses cursor-based pagination (via `pageToken`/`nextPageToken`) rather than offset-based pagination for better performance and consistency, especially with large datasets. Cursor-based pagination avoids the "deep pagination problem" where skipping large numbers of records becomes inefficient for databases. This approach is consistent with the gRPC specification, which also uses cursor-based pagination (page_token/next_page_token).
+
+***Ordering:***
+
+Implementations MUST return tasks sorted by their status timestamp time in descending order (most recently updated tasks first). This ensures consistent pagination and allows clients to efficiently monitor recent task activity.
+
+#### 4.1.5. Cancel Task
+
+Requests the cancellation of an ongoing task. The server will attempt to cancel the task, but success is not guaranteed (e.g., the task might have already completed or failed, or cancellation might not be supported at its current stage).
+
+**Inputs:**
+
+{{ proto_to_table("CancelTaskRequest") }}
+
+**Outputs:**
+
+- Updated [`Task`](#411-task) with cancellation status
+
+**Errors:**
+
+- [`TaskNotCancelableError`](#332-error-handling): The task is not in a cancelable state (e.g., already completed, failed, or canceled).
+- [`TaskNotFoundError`](#332-error-handling): The task ID does not exist or is not accessible.
+
+**Behavior:**
+
+The operation attempts to cancel the specified task and returns its updated state.
+
+#### 4.1.6. Subscribe to Task
+
+<span id="79-taskssubscribe"></span>
+
+Establishes a streaming connection to receive updates for an existing task.
+
+**Inputs:**
+
+{{ proto_to_table("SubscribeToTaskRequest") }}
+
+**Outputs:**
+
+- [`Stream Response`](#323-stream-response) object containing:
+    - Initial response: [`Task`](#411-task) object with current state
+    - Stream of [`TaskStatusUpdateEvent`](#421-taskstatusupdateevent) and [`TaskArtifactUpdateEvent`](#422-taskartifactupdateevent) objects
+
+**Errors:**
+
+- [`UnsupportedOperationError`](#332-error-handling): Streaming is not supported by the agent (see [Capability Validation](#334-capability-validation)).
+- [`TaskNotFoundError`](#332-error-handling): The task ID does not exist or is not accessible.
+- [`UnsupportedOperationError`](#332-error-handling): The operation is attempted on a task that is in a terminal state (`completed`, `failed`, `canceled`, or `rejected`).
+
+**Behavior:**
+
+The operation enables real-time monitoring of task progress and can be used with any task that is not in a terminal state. The stream MUST terminate when the task reaches a terminal state (`completed`, `failed`, `canceled`, or `rejected`).
+
+The operation MUST return a `Task` object as the first event in the stream, representing the current state of the task at the time of subscription. This prevents a potential loss of information between a call to `GetTask` and calling `SubscribeToTask`.
+
+#### 4.1.7. Create Push Notification Config
+
+<span id="75-taskspushnotificationconfigset"></span>
+<span id="317-create-push-notification-config"></span>
+
+Creates a push notification configuration for a task to receive asynchronous updates via webhook.
+
+**Inputs:**
+
+{{ proto_to_table("CreateTaskPushNotificationConfigRequest") }}
+
+**Outputs:**
+
+- [`PushNotificationConfig`](#431-pushnotificationconfig): Created configuration with assigned ID
+
+**Errors:**
+
+- [`PushNotificationNotSupportedError`](#332-error-handling): Push notifications are not supported by the agent (see [Capability Validation](#334-capability-validation)).
+- [`TaskNotFoundError`](#332-error-handling): The task ID does not exist or is not accessible.
+
+**Behavior:**
+
+The operation MUST establish a webhook endpoint for task update notifications. When task updates occur, the agent will send HTTP POST requests to the configured webhook URL with [`StreamResponse`](#323-stream-response) payloads (see [Push Notification Payload](#433-push-notification-payload) for details). This operation is only available if the agent supports push notifications capability. The configuration MUST persist until task completion or explicit deletion.
+
+ <span id="tasks-push-notification-config-operations"></span><span id="grpc-push-notification-operations"></span><span id="push-notification-operations"></span>
+
+#### 4.1.8. Get Push Notification Config
+
+<span id="76-taskspushnotificationconfigget"></span>
+
+Retrieves an existing push notification configuration for a task.
+
+**Inputs:**
+
+{{ proto_to_table("GetTaskPushNotificationConfigRequest") }}
+
+**Outputs:**
+
+- [`PushNotificationConfig`](#431-pushnotificationconfig): The requested configuration
+
+**Errors:**
+
+- [`PushNotificationNotSupportedError`](#332-error-handling): Push notifications are not supported by the agent (see [Capability Validation](#334-capability-validation)).
+- [`TaskNotFoundError`](#332-error-handling): The push notification configuration does not exist.
+
+**Behavior:**
+
+The operation MUST return configuration details including webhook URL and notification settings. The operation MUST fail if the configuration does not exist or the client lacks access.
+
+#### 4.1.9. List Push Notification Configs
+
+Retrieves all push notification configurations for a task.
+
+**Inputs:**
+
+{{ proto_to_table("ListTaskPushNotificationConfigsRequest") }}
+
+**Outputs:**
+
+{{ proto_to_table("ListTaskPushNotificationConfigsResponse") }}
+
+**Errors:**
+
+- [`PushNotificationNotSupportedError`](#332-error-handling): Push notifications are not supported by the agent (see [Capability Validation](#334-capability-validation)).
+- [`TaskNotFoundError`](#332-error-handling): The task ID does not exist or is not accessible.
+
+**Behavior:**
+
+The operation MUST return all active push notification configurations for the specified task and MAY support pagination for tasks with many configurations.
+
+#### 4.1.10. Delete Push Notification Config
+
+Removes a push notification configuration for a task.
+
+**Inputs:**
+
+{{ proto_to_table("DeleteTaskPushNotificationConfigRequest") }}
+
+**Outputs:**
+
+- Confirmation of deletion (implementation-specific)
+
+**Errors:**
+
+- [`PushNotificationNotSupportedError`](#332-error-handling): Push notifications are not supported by the agent (see [Capability Validation](#334-capability-validation)).
+- [`TaskNotFoundError`](#332-error-handling): The task ID does not exist.
+
+**Behavior:**
+
+The operation MUST permanently remove the specified push notification configuration. No further notifications will be sent to the configured webhook after deletion. This operation MUST be idempotent - multiple deletions of the same config have the same effect.
+
+#### 4.1.11. Get Extended Agent Card
+
+Retrieves a potentially more detailed version of the Agent Card after the client has authenticated. This endpoint is available only if `AgentCard.capabilities.extendedAgentCard` is `true`.
+
+**Inputs:**
+
+{{ proto_to_table("GetExtendedAgentCardRequest") }}
+
+**Outputs:**
+
+- [`AgentCard`](#441-agentcard): A complete Agent Card object, which may contain additional details or skills not present in the public card
+
+**Errors:**
+
+- [`UnsupportedOperationError`](#332-error-handling): The agent does not support authenticated extended cards (see [Capability Validation](#334-capability-validation)).
+- [`ExtendedAgentCardNotConfiguredError`](#332-error-handling): The agent declares support but does not have an extended agent card configured.
+
+**Behavior:**
+
+- **Authentication**: The client MUST authenticate the request using one of the schemes declared in the public `AgentCard.securitySchemes` and `AgentCard.security` fields.
+- **Extended Information**: The operation MAY return different details based on client authentication level, including additional skills, capabilities, or configuration not available in the public Agent Card.
+- **Card Replacement**: Clients retrieving this extended card SHOULD replace their cached public Agent Card with the content received from this endpoint for the duration of their authenticated session or until the card's version changes.
+- **Availability**: This operation is only available if the public Agent Card declares `capabilities.extendedAgentCard: true`.
+
+For detailed security guidance on extended agent cards, see [Section 13.3 Extended Agent Card Access Control](#133-extended-agent-card-access-control).
+
+### 4.2. Operation Parameter Objects
+
+This section defines common parameter objects used across multiple operations.
+
+#### 4.2.1. SendMessageRequest
+
+{{ proto_to_table("SendMessageRequest") }}
+
+#### 4.2.2. SendMessageConfiguration
+
+{{ proto_to_table("SendMessageConfiguration") }}
+
+**Execution Mode:**
+
+The `return_immediately` field in [`SendMessageConfiguration`](#322-sendmessageconfiguration) controls whether the operation returns immediately or waits for task completion. Operations are blocking by default:
+
+- **Blocking (`return_immediately: false` or unset)**: The operation MUST wait until the task reaches a terminal state (`COMPLETED`, `FAILED`, `CANCELED`, `REJECTED`) or an interrupted state (`INPUT_REQUIRED`, `AUTH_REQUIRED`) before returning. The response MUST include the latest task state with all artifacts and status information. This is the default behavior.
+
+- **Non-Blocking (`return_immediately: true`)**: The operation MUST return immediately after creating the task, even if processing is still in progress. The returned task will have an in-progress state (e.g., `working`, `input_required`). It is the caller's responsibility to poll for updates using [Get Task](#313-get-task), subscribe via [Subscribe to Task](#316-subscribe-to-task), or receive updates via push notifications.
+
+The `return_immediately` field has no effect:
+
+- when the operation returns a direct [`Message`](#414-message) response instead of a task.
+- for streaming operations, which always return updates in real-time.
+- on configured push notification configurations, which operates independently of execution mode.
+
+#### 4.2.3. Stream Response
+
+<span id="323-stream-response"></span>
+<span id="72-messagestream"></span>
+
+{{ proto_to_table("StreamResponse") }}
+
+This wrapper allows streaming endpoints to return different types of updates through a single response stream while maintaining type safety.
+
+#### 4.2.4. History Length Semantics
+
+The `historyLength` parameter appears in multiple operations and controls how much task history is returned in responses. This parameter follows consistent semantics across all operations:
+
+- **Unset/undefined**: No limit imposed; server returns its default amount of history (implementation-defined, may be all history)
+- **0**: No history should be returned; the `history` field SHOULD be omitted
+- **> 0**: Return at most this many recent messages from the task's history
+
+#### 4.2.5. Metadata
+
+A flexible key-value map for passing additional context or parameters with operations. Metadata keys and are strings and values can be any valid value that can be represented in JSON. [`Extensions`](#46-extensions) can be used to strongly type metadata values for specific use cases.
+
+#### 4.2.6 Service Parameters
+
+A key-value map for passing horizontally applicable context or parameters with case-insensitive string keys and case-sensitive string values. The transmission mechanism for these service parameter key-value pairs is defined by the specific protocol binding (e.g., HTTP headers for HTTP-based bindings, gRPC metadata for gRPC bindings). Custom protocol bindings **MUST** specify how service parameters are transmitted in their binding specification.
+
+**Standard A2A Service Parameters:**
+
+| Name             | Description                                                                                                                                             | Example Value                                                                                 |
+| :--------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------ | :-------------------------------------------------------------------------------------------- |
+| `A2A-Extensions` | Comma-separated list of extension URIs that the client wants to use for the request                                                                     | `https://example.com/extensions/geolocation/v1,https://standards.org/extensions/citations/v1` |
+| `A2A-Version`    | The A2A protocol version that the client is using. If the version is not supported, the agent returns [`VersionNotSupportedError`](#332-error-handling) | `0.3`                                                                                         |
+
+As service parameter names MAY need to co-exist with other parameters defined by the underlying transport protocol or infrastructure, all service parameters defined by this specification will be prefixed with `a2a-`.
+
+### 4.3. Operation Semantics
+
+#### 4.3.1. Idempotency
+
+- **Get operations** (Get Task, List Tasks, Get Extended Agent Card) are naturally idempotent
+- **Send Message** operations MAY be idempotent. Agents may utilize the messageId to detect duplicate messages.
+- **Cancel Task** operations are idempotent - multiple cancellation requests have the same effect. A duplicate cancellation request MAY return `TaskNotFoundError` if the task has already been canceled and purged.
+
+#### 4.3.2. Error Handling
+
+All operations may return errors in the following categories. Servers **MUST** return appropriate errors and **SHOULD** provide actionable information to help clients resolve issues.
+
+**Error Categories and Server Requirements:**
+
+- **Authentication Errors**: Invalid or missing credentials
+    - Servers **MUST** reject requests with invalid or missing authentication credentials
+    - Servers **SHOULD** include authentication challenge information in the error response
+    - Servers **SHOULD** specify which authentication scheme is required
+    - Example error codes: HTTP `401 Unauthorized`, gRPC `UNAUTHENTICATED`, JSON-RPC custom error
+    - Example scenarios: Missing bearer token, expired API key, invalid OAuth token
+
+- **Authorization Errors**: Insufficient permissions for requested operation
+    - Servers **MUST** return an authorization error when the authenticated client lacks required permissions
+    - Servers **SHOULD** indicate what permission or scope is missing (without leaking sensitive information about resources the client cannot access)
+    - Servers **MUST NOT** reveal the existence of resources the client is not authorized to access
+    - Example error codes: HTTP `403 Forbidden`, gRPC `PERMISSION_DENIED`, JSON-RPC custom error
+    - Example scenarios: Attempting to access a task created by another user, insufficient OAuth scopes
+
+- **Validation Errors**: Invalid input parameters or message format
+    - Servers **MUST** validate all input parameters before processing
+    - Servers **SHOULD** specify which parameter(s) failed validation and why
+    - Servers **SHOULD** provide guidance on valid parameter values or formats
+    - Example error codes: HTTP `400 Bad Request`, gRPC `INVALID_ARGUMENT`, JSON-RPC `-32602 Invalid params`
+    - Example scenarios: Invalid task ID format, missing required message parts, unsupported content type
+
+- **Resource Errors**: Requested task not found or not accessible
+    - Servers **MUST** return a not found error when a requested resource does not exist or is not accessible to the authenticated client
+    - Servers **SHOULD NOT** distinguish between "does not exist" and "not authorized" to prevent information leakage
+    - Example error codes: HTTP `404 Not Found`, gRPC `NOT_FOUND`, JSON-RPC custom error (see A2A-specific errors)
+    - Example scenarios: Task ID does not exist, task has been deleted, configuration not found
+
+- **System Errors**: Internal agent failures or temporary unavailability
+    - Servers **SHOULD** return appropriate error codes for temporary failures vs. permanent errors
+    - Servers **MAY** include retry guidance (e.g., Retry-After header in HTTP)
+    - Servers **SHOULD** log system errors for diagnostic purposes
+    - Example error codes: HTTP `500 Internal Server Error` or `503 Service Unavailable`, gRPC `INTERNAL` or `UNAVAILABLE`, JSON-RPC `-32603 Internal error`
+    - Example scenarios: Database connection failure, downstream service timeout, rate limit exceeded
+
+**Error Payload Structure:**
+
+All error responses in the A2A protocol, regardless of binding, **MUST** convey the following information:
+
+1. **Error Code**: A machine-readable identifier for the error type (e.g., string code, numeric code, or protocol-specific status)
+2. **Error Message**: A human-readable description of the error
+3. **Error Details** (optional): An array of objects providing additional structured information about the error. Each object in the array **MUST** include a `@type` key that identifies the object's type (using [ProtoJSON `Any` representation](https://protobuf.dev/programming-guides/json)). Well-known types from the [`google.rpc` error model](https://cloud.google.com/apis/design/errors#error_model) (e.g., `ErrorInfo`, `BadRequest`) **SHOULD** be used where applicable. Error details may be used for:
+    - Affected fields or parameters
+    - Contextual information (e.g., task ID, timestamp)
+    - Suggestions for resolution
+
+Protocol bindings **MUST** map these elements to their native error representations while preserving semantic meaning. See binding-specific sections for concrete error format examples: [JSON-RPC Error Handling](#95-error-handling), [gRPC Error Handling](#106-error-handling), and [HTTP/REST Error Handling](#116-error-handling).
+
+**A2A-Specific Errors:**
+
+| Error Name                            | Description                                                                                                                                                       |
+| :------------------------------------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TaskNotFoundError`                   | The specified task ID does not correspond to an existing or accessible task. It might be invalid, expired, or already completed and purged.                       |
+| `TaskNotCancelableError`              | An attempt was made to cancel a task that is not in a cancelable state (e.g., it has already reached a terminal state like `completed`, `failed`, or `canceled`). |
+| `PushNotificationNotSupportedError`   | Client attempted to use push notification features but the server agent does not support them (i.e., `AgentCard.capabilities.pushNotifications` is `false`).      |
+| `UnsupportedOperationError`           | The requested operation or a specific aspect of it is not supported by this server agent implementation.                                                          |
+| `ContentTypeNotSupportedError`        | A Media Type provided in the request's message parts or implied for an artifact is not supported by the agent or the specific skill being invoked.                |
+| `InvalidAgentResponseError`           | An agent returned a response that does not conform to the specification for the current method.                                                                   |
+| `ExtendedAgentCardNotConfiguredError` | The agent does not have an extended agent card configured when one is required for the requested operation.                                                       |
+| `ExtensionSupportRequiredError`       | Server requested use of an extension marked as `required: true` in the Agent Card but the client did not declare support for it in the request.                   |
+| `VersionNotSupportedError`            | The A2A protocol version specified in the request (via `A2A-Version` service parameter) is not supported by the agent.                                            |
+
+#### 4.3.3. Asynchronous Processing
+
+A2A operations are designed for asynchronous task execution. Operations return immediately with either [`Task`](#411-task) objects or [`Message`](#414-message) objects, and when a Task is returned, processing continues in the background. Clients retrieve task updates through polling, streaming, or push notifications (see [Section 3.5](#35-task-update-delivery-mechanisms)). Agents MAY accept additional messages for tasks in non-terminal states to enable multi-turn interactions (see [Section 3.4](#34-multi-turn-interactions)).
+
+#### 4.3.4. Capability Validation
+
+Agents declare optional capabilities in their [`AgentCard`](#441-agentcard). When clients attempt to use operations or features that require capabilities not declared as supported in the Agent Card, the agent **MUST** return an appropriate error response:
+
+- **Push Notifications**: If `AgentCard.capabilities.pushNotifications` is `false` or not present, operations related to push notification configuration (Create, Get, List, Delete) **MUST** return [`PushNotificationNotSupportedError`](#332-error-handling).
+- **Streaming**: If `AgentCard.capabilities.streaming` is `false` or not present, attempts to use `SendStreamingMessage` or `SubscribeToTask` operations **MUST** return [`UnsupportedOperationError`](#332-error-handling).
+- **Extended Agent Card**: If `AgentCard.capabilities.extendedAgentCard` is `false` or not present, attempts to call the Get Extended Agent Card operation **MUST** return [`UnsupportedOperationError`](#332-error-handling). If the agent declares support but has not configured an extended card, it **MUST** return [`ExtendedAgentCardNotConfiguredError`](#332-error-handling).
+- **Extensions**: When a server requests use of an extension marked as `required: true` in the Agent Card but the client does not declare support for it, the agent **MUST** return [`ExtensionSupportRequiredError`](#332-error-handling).
+
+Clients **SHOULD** validate capability support by examining the Agent Card before attempting operations that require optional capabilities.
+
+### 4.4. Multi-Turn Interactions
+
+The A2A protocol supports multi-turn conversations through context identifiers and task references, enabling agents to maintain conversational continuity across multiple interactions.
+
+#### 4.4.1. Context Identifier Semantics
+
+A `contextId` is an identifier that logically groups multiple related [`Task`](#411-task) and [`Message`](#414-message) objects, providing continuity across a series of interactions.
+
+**Generation and Assignment:**
+
+- Agents **MAY** generate a new `contextId` when processing a [`Message`](#414-message) that does not include a `contextId` field
+- If an agent generates a new `contextId`, it **MUST** be included in the response (either [`Task`](#411-task) or [`Message`](#414-message))
+- Agents **MAY** accept and preserve client-provided `contextId` values
+- If an agent cannot accept a client-provided `contextId`, it **MUST** reject the request with an error and **MUST NOT** generate a new `contextId` for the response
+- Clients **SHOULD NOT** provide a client-generated `contextId` to a server unless they understand how the server will process that `contextId`
+- Server-generated `contextId` values **SHOULD** be treated as opaque identifiers by clients
+
+**Grouping and Scope:**
+
+- A `contextId` logically groups multiple [`Task`](#411-task) objects and [`Message`](#414-message) objects that are part of the same conversational context
+- All tasks and messages with the same `contextId` **SHOULD** be treated as part of the same conversational session
+- Agents **MAY** use the `contextId` to maintain internal state, conversational history, or LLM context across multiple interactions
+- Agents **MAY** implement context expiration or cleanup policies and **SHOULD** document any such policies
+
+#### 4.4.2. Task Identifier Semantics
+
+A `taskId` is a unique identifier for a [`Task`](#411-task) object, representing a stateful unit of work with a defined lifecycle.
+
+**Generation and Assignment:**
+
+- Task IDs are **server-generated** when a new task is created in response to a [`Message`](#414-message)
+- Agents **MUST** generate a unique `taskId` for each new task they create
+- The generated `taskId` **MUST** be included in the [`Task`](#411-task) object returned to the client
+- When a client includes a `taskId` in a [`Message`](#414-message), it **MUST** reference an existing task
+- Agents **MUST** return a [`TaskNotFoundError`](#332-error-handling) if the provided `taskId` does not correspond to an existing task
+- Client-provided `taskId` values for creating new tasks is **NOT** supported
+
+#### 4.4.3. Multi-Turn Conversation Patterns
+
+The A2A protocol supports several patterns for multi-turn interactions:
+
+**Context Continuity:**
+
+- [`Task`](#411-task) objects maintain conversation context through the `contextId` field
+- Clients **MAY** include the `contextId` in subsequent messages to indicate continuation of a previous interaction
+- Clients **MAY** use `taskId` (with or without `contextId`) to continue or refine a specific task
+- Clients **MAY** use `contextId` without `taskId` to start a new task within an existing conversation context
+- Agents **MUST** infer `contextId` from the task if only `taskId` is provided
+- Agents **MUST** reject messages containing mismatching `contextId` and `taskId` (i.e., the provided `contextId` is different from that of the referenced [`Task`](#411-task)).
+
+**Input Required State:**
+
+- Agents can request additional input mid-processing by transitioning a task to the `input-required` state
+- The client continues the interaction by sending a new message with the same `taskId` and `contextId`
+
+**Follow-up Messages:**
+
+- Clients can send additional messages with `taskId` references to continue or refine existing tasks
+- Clients **SHOULD** use the `referenceTaskIds` field in [`Message`](#414-message) to explicitly reference related tasks
+- Agents **SHOULD** use referenced tasks to understand the context and intent of follow-up requests
+
+**Context Inheritance:**
+
+- New tasks created within the same `contextId` can inherit context from previous interactions
+- Agents **SHOULD** leverage the shared `contextId` to provide contextually relevant responses
+
+### 4.5. Task Update Delivery Mechanisms
+
+The A2A protocol provides three complementary mechanisms for clients to receive updates about task progress and completion.
+
+#### 4.5.1. Overview of Update Mechanisms
+
+**Polling (Get Task):**
+
+- Client periodically calls Get Task ([Section 3.1.3](#313-get-task)) to check task status
+- Simple to implement, works with all protocol bindings
+- Higher latency, potential for unnecessary requests
+- Best for: Simple integrations, infrequent updates, clients behind restrictive firewalls
+
+**Streaming:**
+
+- Real-time delivery of events as they occur
+- Operations: Stream Message ([Section 3.1.2](#312-send-streaming-message)) and Subscribe to Task ([Section 3.1.6](#316-subscribe-to-task))
+- Low latency, efficient for frequent updates
+- Requires persistent connection support
+- Best for: Interactive applications, real-time dashboards, live progress monitoring
+- Requires `AgentCard.capabilities.streaming` to be `true`
+
+**Push Notifications (WebHooks):**
+
+- Agent sends HTTP POST requests to client-registered endpoints when task state changes
+- Client does not maintain persistent connection
+- Asynchronous delivery, client must be reachable via HTTP
+- Best for: Server-to-server integrations, long-running tasks, event-driven architectures
+- Operations: Create ([Section 3.1.7](#317-create-push-notification-config)), Get ([Section 3.1.8](#76-taskspushnotificationconfigget)), List ([Section 3.1.9](#319-list-push-notification-configs)), Delete ([Section 3.1.10](#3110-delete-push-notification-config))
+- Event types: TaskStatusUpdateEvent ([Section 4.2.1](#421-taskstatusupdateevent)), TaskArtifactUpdateEvent ([Section 4.2.2](#422-taskartifactupdateevent)), WebHook payloads ([Section 4.3](#43-push-notification-objects))
+- Requires `AgentCard.capabilities.pushNotifications` to be `true`
+- Regardless of the protocol binding being used by the agent, WebHook calls use plain HTTP and the JSON payloads as defined in the HTTP protocol binding
+
+#### 4.5.2. Streaming Event Delivery
+
+**Event Ordering:**
+
+All implementations MUST deliver events in the order they were generated. Events MUST NOT be reordered during transmission, regardless of protocol binding.
+
+**Multiple Streams Per Task:**
+
+An agent MAY serve multiple concurrent streams to one or more clients for the same task. This allows multiple clients (or the same client with multiple connections) to independently subscribe to and receive updates about a task's progress.
+
+When multiple streams are active for a task:
+
+- Events MUST be broadcast to all active streams for that task
+- Each stream MUST receive the same events in the same order
+- Closing one stream MUST NOT affect other active streams for the same task
+- The task lifecycle is independent of any individual stream's lifecycle
+
+This capability enables scenarios such as:
+
+- Multiple team members monitoring the same long-running task
+- A client reconnecting to a task after a network interruption by opening a new stream
+- Different applications or dashboards displaying real-time updates for the same task
+
+#### 4.5.3. Push Notification Delivery
+
+Push notifications are delivered via HTTP POST to client-registered webhook endpoints. The delivery semantics and reliability guarantees are defined in [Section 4.3](#43-push-notification-objects).
+
+### 4.6 Versioning
+
+The specific version of the A2A protocol in use is identified using the `Major.Minor` elements (e.g. `1.0`) of the corresponding A2A specification version. Patch version numbers used by the specification, do not affect protocol compatibility. Patch version numbers SHOULD NOT be used in requests, responses and Agent Cards, and MUST not be considered when clients and servers negotiate protocol versions.
+
+#### 4.6.1 Client Responsibilities
+
+Clients MUST send the `A2A-Version` header with each request to maintain compatibility after an agent upgrades to a new version of the protocol (except for 0.3 Clients - 0.3 will be assumed for empty header). Sending the `A2A-Version` header also provides visibility to agents about version usage in the ecosystem, which can help inform the risks of inplace version upgrades.
+
+**Example of HTTP GET Request with Version Header:**
+
+```http
+GET /tasks/task-123 HTTP/1.1
+Host: agent.example.com
+A2A-Version: 1.0
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+Accept: application/json
+```
+
+Clients MAY provide the `A2A-Version` as a request parameter instead of a header.
+
+**Example of HTTP GET Request with Version request parameter:**
+
+```http
+GET /tasks/task-123?A2A-Version=1.0 HTTP/1.1
+Host: agent.example.com
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+Accept: application/json
+```
+
+#### 4.6.2 Server Responsibilities
+
+Agents MUST process requests using the semantics of the requested `A2A-Version` (matching `Major.Minor`). If the version is not supported by the interface, agents MUST return a [`VersionNotSupportedError`](#332-error-handling).
+
+Agents MUST interpret empty value as 0.3 version.
+
+Agents CAN expose multiple interfaces for the same transport with different versions under the same or different URLs.
+
+#### 4.6.3 Tooling support
+
+Tooling libraries and SDKs that implement the A2A protocol MUST provide mechanisms to help clients manage protocol versioning, such as negotiation of the transport and protocol version used. Client Agents that require the latest features of the protocol should be configured to request specific versions and avoid automatic fallback to older versions, to prevent silently losing functionality.
+
+### 4.7 Messages and Artifacts
+
+Messages and Artifacts serve distinct purposes within the A2A protocol. The core interaction model defined by A2A is for clients to send messages to initiate a task that produces one or more artifacts.
+
+Messages play several key roles:
+
+- **Task Initiation**: Clients send Messages to agents to initiate new tasks.
+- **Clarification Messages**: Agents may send Messages back to the client to request clarification prior to initiating a task.
+- **Status Messages**: Agents attach Messages to status update events to inform clients about task progress, request additional input, or provide informational updates.
+- **Task Interaction**: Clients send Messages to provide additional input or instructions for ongoing tasks.
+
+Messages SHOULD NOT be used to deliver task outputs. Results SHOULD BE returned using Artifacts associated with a Task. This separation allows for a clear distinction between communication (Messages) and data output (Artifacts).
+
+The Task History field contains Messages exchanged during task execution. However, not all Messages are guaranteed to be persisted in the Task history; for example, transient informational messages may not be stored. Messages exchanged prior to task creation may not be stored in Task history. The agent is responsible to determine which Messages are persisted in the Task History.
+
+Clients using streaming to retrieve task updates MAY not receive all status update messages if the client is disconnected and then reconnects. Messages MUST NOT be considered a reliable delivery mechanism for critical information.
+
+Agents MAY choose to persist all Messages that contain important information in the Task history to ensure clients can retrieve it later. However, clients MUST NOT rely on this behavior unless negotiated out-of-band.
 ## 5. Protocol Binding Requirements and Interoperability
 
 ### 5.1. Functional Equivalence Requirements

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -521,7 +521,6 @@ Extensions **SHOULD** include version information in their URI identifier. This 
 
 If a client requests a versions of an extension that the agent does not support, the agent **SHOULD** ignore the extension for that interaction and proceed without it, unless the extension is marked as `required` in the AgentCard, in which case the agent **MUST** return an error indicating unsupported extension. It **MUST NOT** fall back to a previous version of the extension automatically.
 
-
 ## 4. Protocol Operations
 
 This section describes the core operations of the A2A protocol in a binding-independent manner. These operations define the fundamental capabilities that all A2A implementations must support, regardless of the underlying binding mechanism.
@@ -859,7 +858,7 @@ A key-value map for passing horizontally applicable context or parameters with c
 **Standard A2A Service Parameters:**
 
 | Name             | Description                                                                                                                                             | Example Value                                                                                 |
-| :--------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------ | :-------------------------------------------------------------------------------------------- |
+|:-----------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------|:----------------------------------------------------------------------------------------------|
 | `A2A-Extensions` | Comma-separated list of extension URIs that the client wants to use for the request                                                                     | `https://example.com/extensions/geolocation/v1,https://standards.org/extensions/citations/v1` |
 | `A2A-Version`    | The A2A protocol version that the client is using. If the version is not supported, the agent returns [`VersionNotSupportedError`](#432-error-handling) | `0.3`                                                                                         |
 
@@ -929,7 +928,7 @@ Protocol bindings **MUST** map these elements to their native error representati
 **A2A-Specific Errors:**
 
 | Error Name                            | Description                                                                                                                                                       |
-| :------------------------------------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|:--------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `TaskNotFoundError`                   | The specified task ID does not correspond to an existing or accessible task. It might be invalid, expired, or already completed and purged.                       |
 | `TaskNotCancelableError`              | An attempt was made to cancel a task that is not in a cancelable state (e.g., it has already reached a terminal state like `completed`, `failed`, or `canceled`). |
 | `PushNotificationNotSupportedError`   | Client attempted to use push notification features but the server agent does not support them (i.e., `AgentCard.capabilities.pushNotifications` is `false`).      |
@@ -1140,6 +1139,7 @@ The Task History field contains Messages exchanged during task execution. Howeve
 Clients using streaming to retrieve task updates MAY not receive all status update messages if the client is disconnected and then reconnects. Messages MUST NOT be considered a reliable delivery mechanism for critical information.
 
 Agents MAY choose to persist all Messages that contain important information in the Task history to ensure clients can retrieve it later. However, clients MUST NOT rely on this behavior unless negotiated out-of-band.
+
 ## 5. Protocol Binding Requirements and Interoperability
 
 ### 5.1. Functional Equivalence Requirements
@@ -1160,7 +1160,7 @@ When an agent supports multiple protocols, all supported protocols **MUST**:
 ### 5.3. Method Mapping Reference
 
 | Functionality                   | JSON-RPC Method                    | gRPC Method                        | REST Endpoint                                           |
-| :------------------------------ | :--------------------------------- | :--------------------------------- | :------------------------------------------------------ |
+|:--------------------------------|:-----------------------------------|:-----------------------------------|:--------------------------------------------------------|
 | Send message                    | `SendMessage`                      | `SendMessage`                      | `POST /message:send`                                    |
 | Stream message                  | `SendStreamingMessage`             | `SendStreamingMessage`             | `POST /message:stream`                                  |
 | Get task                        | `GetTask`                          | `GetTask`                          | `GET /tasks/{id}`                                       |
@@ -1177,17 +1177,17 @@ When an agent supports multiple protocols, all supported protocols **MUST**:
 
 All A2A-specific errors defined in [Section 4.3.2](#432-error-handling) **MUST** be mapped to binding-specific error representations. The following table provides the canonical mappings for each standard protocol binding:
 
-| A2A Error Type                        | JSON-RPC Code | gRPC Status           | HTTP Status                  |
-| :------------------------------------ | :------------ | :-------------------- | :--------------------------- |
-| `TaskNotFoundError`                   | `-32001`      | `NOT_FOUND`           | `404 Not Found`              |
-| `TaskNotCancelableError`              | `-32002`      | `FAILED_PRECONDITION` | `400 Bad Request`            |
-| `PushNotificationNotSupportedError`   | `-32003`      | `FAILED_PRECONDITION` | `400 Bad Request`            |
-| `UnsupportedOperationError`           | `-32004`      | `FAILED_PRECONDITION`       | `400 Bad Request`        |
-| `ContentTypeNotSupportedError`        | `-32005`      | `INVALID_ARGUMENT`    | `400 Bad Request`            |
-| `InvalidAgentResponseError`           | `-32006`      | `INTERNAL`            | `500 Internal Server Error`  |
-| `ExtendedAgentCardNotConfiguredError` | `-32007`      | `FAILED_PRECONDITION` | `400 Bad Request`            |
-| `ExtensionSupportRequiredError`       | `-32008`      | `FAILED_PRECONDITION` | `400 Bad Request`            |
-| `VersionNotSupportedError`            | `-32009`      | `FAILED_PRECONDITION`       | `400 Bad Request`        |
+| A2A Error Type                        | JSON-RPC Code | gRPC Status           | HTTP Status                 |
+|:--------------------------------------|:--------------|:----------------------|:----------------------------|
+| `TaskNotFoundError`                   | `-32001`      | `NOT_FOUND`           | `404 Not Found`             |
+| `TaskNotCancelableError`              | `-32002`      | `FAILED_PRECONDITION` | `400 Bad Request`           |
+| `PushNotificationNotSupportedError`   | `-32003`      | `FAILED_PRECONDITION` | `400 Bad Request`           |
+| `UnsupportedOperationError`           | `-32004`      | `FAILED_PRECONDITION` | `400 Bad Request`           |
+| `ContentTypeNotSupportedError`        | `-32005`      | `INVALID_ARGUMENT`    | `400 Bad Request`           |
+| `InvalidAgentResponseError`           | `-32006`      | `INTERNAL`            | `500 Internal Server Error` |
+| `ExtendedAgentCardNotConfiguredError` | `-32007`      | `FAILED_PRECONDITION` | `400 Bad Request`           |
+| `ExtensionSupportRequiredError`       | `-32008`      | `FAILED_PRECONDITION` | `400 Bad Request`           |
+| `VersionNotSupportedError`            | `-32009`      | `FAILED_PRECONDITION` | `400 Bad Request`           |
 
 **Custom Binding Requirements:**
 
@@ -2440,7 +2440,7 @@ JSON-RPC error responses use the standard [JSON-RPC 2.0 error object](https://ww
 **Standard JSON-RPC Error Codes:**
 
 | JSON-RPC Error Code | Error Name            | Standard Message                   | Description                                             |
-| :------------------ | :-------------------- | :--------------------------------- | :------------------------------------------------------ |
+|:--------------------|:----------------------|:-----------------------------------|:--------------------------------------------------------|
 | `-32700`            | `JSONParseError`      | "Invalid JSON payload"             | The server received invalid JSON                        |
 | `-32600`            | `InvalidRequestError` | "Request payload validation error" | The JSON sent is not a valid Request object             |
 | `-32601`            | `MethodNotFoundError` | "Method not found"                 | The requested method does not exist or is not available |
@@ -2860,7 +2860,7 @@ Query parameter names **MUST** use `camelCase` to match the JSON serialization o
 **Example Mappings:**
 
 | Protocol Buffer Field | Query Parameter Name | Example Usage       |
-| --------------------- | -------------------- | ------------------- |
+|-----------------------|----------------------|---------------------|
 | `context_id`          | `contextId`          | `?contextId=uuid`   |
 | `page_size`           | `pageSize`           | `?pageSize=50`      |
 | `page_token`          | `pageToken`          | `?pageToken=cursor` |
@@ -2981,7 +2981,7 @@ While the A2A protocol provides three standard bindings (JSON-RPC, gRPC, and HTT
 
 Custom protocol bindings **MUST**:
 
-1. **Implement All Core Operations**: Support all operations defined in [Section 4 (A2A Protocol Operations)](#4-a2a-protocol-operations)
+1. **Implement All Core Operations**: Support all operations defined in [Section 4 (A2A Protocol Operations)](#4-protocol-operations)
 2. **Preserve Data Model**: Use data structures functionally equivalent to those defined in [Section 3 (Protocol Data Model)](#3-protocol-data-model)
 3. **Maintain Semantics**: Ensure operations behave consistently with the abstract operation definitions
 4. **Document Completely**: Provide comprehensive documentation of the binding specification
@@ -3077,7 +3077,7 @@ Implementations **MUST** ensure appropriate scope limitation based on the authen
 
 **Authorization Principles:**
 
-- Servers **MUST** implement authorization checks on every [A2A Protocol Operations](#4-a2a-protocol-operations) request
+- Servers **MUST** implement authorization checks on every [A2A Protocol Operations](#4-protocol-operations) request
 - Implementations **MUST** scope results to the caller's authorized access boundaries as defined by the agent's authorization model
 - Even when `contextId` or other filter parameters are not specified in requests, implementations **MUST** scope results to the caller's authorized access boundaries
 - Authorization models are agent-defined and **MAY** be based on:
@@ -3341,9 +3341,9 @@ The `.well-known/agent-card.json` URI provides a standardized location for disco
 
 - The Agent Card MAY contain public information about an agent's capabilities and SHOULD NOT include sensitive credentials or internal implementation details
 - Implementations SHOULD support HTTPS to ensure authenticity and integrity of the Agent Card
-- Agent Cards MAY be signed using JSON Web Signatures (JWS) as specified in the AgentCardSignature object ([Section 3.4.7](#347-agentcardsignature))
+- Agent Cards MAY be signed using JSON Web Signatures (JWS) as specified in the AgentCardSignature object (Section 3.4.7)
 - Clients SHOULD verify signatures when present to ensure the Agent Card has not been tampered with
-- Extended Agent Cards retrieved via authenticated endpoints ((Section 4.1.11)[#4111-get-extended-agent-card]) MAY contain additional information and MUST enforce appropriate access controls
+- Extended Agent Cards retrieved via authenticated endpoints (Section 4.1.11) MAY contain additional information and MUST enforce appropriate access controls
 
 **Example:**
 
@@ -3358,7 +3358,7 @@ https://agent.example.com/.well-known/agent-card.json
 This appendix catalogs renamed protocol messages and objects, their legacy identifiers, and the planned deprecation/removal schedule. All legacy names and anchors MUST remain resolvable until the stated earliest removal version.
 
 | Legacy Name                                     | Current Name                              | Earliest Removal Version | Notes                                                  |
-| ----------------------------------------------- | ----------------------------------------- | ------------------------ | ------------------------------------------------------ |
+|-------------------------------------------------|-------------------------------------------|--------------------------|--------------------------------------------------------|
 | `MessageSendParams`                             | `SendMessageRequest`                      | >= 0.5.0                 | Request payload rename for clarity (request vs params) |
 | `SendMessageSuccessResponse`                    | `SendMessageResponse`                     | >= 0.5.0                 | Unified success response naming                        |
 | `SendStreamingMessageSuccessResponse`           | `StreamResponse`                          | >= 0.5.0                 | Shorter, binding-agnostic streaming response           |

--- a/docs/topics/agent-discovery.md
+++ b/docs/topics/agent-discovery.md
@@ -81,7 +81,7 @@ Agent Cards include sensitive information, such as:
 
 To mitigate risks, the following protection mechanisms should be considered:
 
-- **Authenticated Agent Cards:** We recommend the use of [authenticated extended agent cards](../specification.md#3111-get-extended-agent-card) for sensitive information or for serving a more detailed version of the card.
+- **Authenticated Agent Cards:** We recommend the use of [authenticated extended agent cards](../specification.md#4111-get-extended-agent-card) for sensitive information or for serving a more detailed version of the card.
 - **Secure Endpoints:** Implement access controls on the HTTP endpoint serving the Agent Card (e.g., `/.well-known/agent-card.json` or registry API). The methods include:
     - Mutual TLS (mTLS)
     - Network restrictions (e.g., IP ranges)

--- a/docs/topics/streaming-and-async.md
+++ b/docs/topics/streaming-and-async.md
@@ -52,7 +52,7 @@ The following key features detail how push notifications are implemented and man
     - Separately, using the `CreateTaskPushNotificationConfig` RPC method for an existing task.
     The `PushNotificationConfig` includes a `url` (the HTTPS webhook URL), an optional `token` (for client-side validation), and optional `authentication` details (for the A2A Server to authenticate to the webhook).
 - **Notification Trigger:** The A2A Server decides when to send a push notification, typically when a task reaches a significant state change (for example, terminal state, `input-required`, or `auth-required`).
-- **Notification Payload:** The A2A protocol defines the HTTP body payload as a [`StreamResponse`](../specification.md#323-stream-response) object, matching the format used in streaming operations. The payload contains one of: `task`, `message`, `statusUpdate`, or `artifactUpdate`. See [Push Notification Payload](../specification.md#pushnotificationpayload) for detailed structure.
+- **Notification Payload:** The A2A protocol defines the HTTP body payload as a [`StreamResponse`](../specification.md#423-stream-response) object, matching the format used in streaming operations. The payload contains one of: `task`, `message`, `statusUpdate`, or `artifactUpdate`. See [Push Notification Payload](../specification.md#pushnotificationpayload) for detailed structure.
 - **Client Action:** Upon receiving a push notification (and successfully verifying its authenticity), the client typically uses the `GetTask` RPC method with the `taskId` from the notification to retrieve the complete, updated `Task` object, including any new artifacts.
 
 ### When to Use Push Notifications
@@ -67,7 +67,7 @@ Push notifications are ideal for:
 
 Refer to the Protocol Specification for detailed structures:
 
-- [`CreateTaskPushNotificationConfig`](../specification.md#317-create-push-notification-config)
+- [`CreateTaskPushNotificationConfig`](../specification.md#417-create-push-notification-config)
 - [`GetTask`](../specification.md#76-taskspushnotificationconfigget)
 
 ### Client-Side Push Notification Service


### PR DESCRIPTION
Swap Section 4 (Protocol Data Model) with Section 3 (A2A Protocol Operations), to better readability.

**Problem:** Right now, Section 3 (Operations) describes how to do things (Send Message, Get Task) using objects that aren't defined until Section 4 (Data Model).

This change is aims to fix this by swapping the sections.

Fix: https://github.com/a2aproject/A2A/issues/1759