### PR TITLE
docs: update SDK count to 6 (added Rust) and resolve lint violations

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,8 +5,8 @@
 ## Near-term initiatives
 
 - Release `1.0` version of the protocol which represents significant maturation of the protocol with enhanced clarity, stronger specifications, and important structural improvements.
-- [What's New in A2A Protocol v1.0](https://a2a-protocol.org/latest/whats-new-v1/) has further updates. 
-- Continue to support additional [A2A extensions](topics/extensions.md) with SDK support. 
+- [What's New in A2A Protocol v1.0](https://a2a-protocol.org/latest/whats-new-v1/) has further updates.
+- Continue to support additional [A2A extensions](topics/extensions.md) with SDK support.
 - Prioritize community-led development with standardized processes for contributing to the specification, SDKs and tooling.
 
 To review recent protocol changes see [Release Notes](https://github.com/a2aproject/A2A/releases).
@@ -17,14 +17,13 @@ To review recent protocol changes see [Release Notes](https://github.com/a2aproj
 
 The TSC looks to streamline opportunities for contribution through [A2A extensions](topics/extensions.md), [Samples](https://github.com/a2aproject/a2a-samples) and participation.
 
-
 ### Validation
 
 As the A2A ecosystem matures, it becomes critical for the A2A community to have tools to validate their agents. The community has launched two efforts to help with validation. Learn more about [A2A Inspector](https://github.com/a2aproject/a2a-inspector) and the [A2A Protocol Technology Compatibility Kit](https://github.com/a2aproject/a2a-tck) (TCK).
 
 ### SDKs
 
-A2A Project currently hosts SDKs in five languages (Python, Go, JS, Java, .NET).
+A2A Project currently hosts SDKs in six languages (Python, Go, JS, Java, .NET, and Rust).
 
 ### Community best practices
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -3,10 +3,10 @@
 ## Python
 
 Tutorial | Description | Difficulty
-:--------|:------------|:-----------
+:-------- | :------------ | :-----------
 [A2A and Python Quickstart](./python/1-introduction.md) | Learn to build a simple Python-based "echo" A2A server and client. | Easy
 [ADK facts](https://github.com/a2aproject/a2a-samples/tree/main/samples/python/agents/adk_facts) | Build and test a simple Personal Assistant agent using the Agent Development Kit (ADK) that can provide interesting facts. | Easy
-[ADK agent on Cloud Run](https://github.com/a2aproject/a2a-samples/tree/main/samples/python/agents/adk_cloud_run) | Deploy, manage, and observe an ADK-based agent as a scalable, serverless service on Google Cloud Run.| Easy
+[ADK agent on Cloud Run](https://github.com/a2aproject/a2a-samples/tree/main/samples/python/agents/adk_cloud_run) | Deploy, manage, and observe an ADK-based agent as a scalable, serverless service on Google Cloud Run. | Easy
 [Multi-agent collaboration using A2A](https://github.com/a2aproject/a2a-samples/tree/main/demo) | Learn how to set up an orchestrator (host agent) that routes and manages requests among several specialized A2A-compatible agents. | Easy
 [Airbnb and weather multi-agent](https://github.com/a2aproject/a2a-samples/tree/main/samples/python/agents/airbnb_planner_multiagent) | Build a complex multi-agent system where agents collaborate using A2A to plan a trip, finding both Airbnb accommodations and weather information. | Medium
 [A2A Client-Server example using remote ADK agent](https://goo.gle/adk-a2a) | Learn how a local A2A client agent discovers and consumes the capabilities of a separate, remote ADK-based agent (for example, a prime number checker). | Easy
@@ -15,7 +15,7 @@ Tutorial | Description | Difficulty
 ## Java
 
 Tutorial | Description | Difficulty
-:--------|:------------|:-----------
+:-------- | :------------ | :-----------
 [Weather Agent](https://github.com/a2aproject/a2a-samples/tree/main/samples/java/agents/weather_mcp) | Build a weather information agent using an MCP server.<br><br>**To make use of this agent in a multi-language, multi-agent system, check out the [weather_and_airbnb_planner sample](https://github.com/a2aproject/a2a-samples/tree/main/samples/python/hosts/weather_and_airbnb_planner).** | Easy
 [Content Writer Agent](https://github.com/a2aproject/a2a-samples/tree/main/samples/java/agents/content_writer) | Build a content writer agent that generates engaging pieces of content from outlines.<br><br>**To make use of this agent in a content creation multi-language, multi-agent system, check out the [content_creation sample](https://github.com/a2aproject/a2a-samples/tree/main/samples/python/hosts/content_creation).** | Easy
 [Content Editor Agent](https://github.com/a2aproject/a2a-samples/tree/main/samples/java/agents/content_editor) | Build a content editor agent that proof-reads and polishes content.<br><br>**To make use of this agent in a content creation multi-language, multi-agent system, check out the [content_creation sample](https://github.com/a2aproject/a2a-samples/tree/main/samples/python/hosts/content_creation).** | Easy
@@ -25,11 +25,11 @@ Tutorial | Description | Difficulty
 ## JavaScript
 
 Tutorial | Description
-:--------|:------------
+:-------- | :------------
 [Movie research agent using JavaScript](https://github.com/a2aproject/a2a-samples/tree/main/samples/js) | Build an A2A agent with Node.js that uses the TMDB (The Movie Database) API to handle movie searches and queries.
 
 ## C#/.NET
 
 Tutorial | Description
-:--------|:------------
+:-------- | :------------
 [All .NET samples](https://github.com/a2aproject/a2a-dotnet/tree/main/samples) | Repository of foundational samples showing how to build A2A clients and servers, including an Echo Agent, using the C#/.NET SDK.


### PR DESCRIPTION
# Description

This PR fixes markdownlint violations in `docs/roadmap.md` and `docs/tutorials/index.md`, and corrects the stale SDK count to reflect the Rust SDK addition from #1729.

Fixes #1875

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/A2A/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [x] Ensure the tests and linter pass
- [x] Appropriate docs were updated (if necessary)

## Changes

### `docs/roadmap.md`
- Remove trailing spaces on lines 8–9 (MD009)
- Remove extra blank line between "Governance" and "Validation" sections (MD012)
- Update SDK count from "five" to "six" and add Rust to the list (added in #1729)

### `docs/tutorials/index.md`
- Fix table separator alignment across all four tables — Python, Java, JavaScript, C#/.NET (MD060)
- Add missing space before pipe in Cloud Run tutorial row (`Run.| Easy` → `Run. | Easy`)

## Verification

```bash
npx markdownlint-cli -c ".github/linters/.markdownlint.json" docs/roadmap.md docs/tutorials/index.md
# Zero errors
```
