### PR TITLE
docs: rename "Stream Message" to "Send Streaming Message" and replace legacy method names

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1162,7 +1162,7 @@ When an agent supports multiple protocols, all supported protocols **MUST**:
 | Functionality                   | JSON-RPC Method                    | gRPC Method                        | REST Endpoint                                           |
 | :------------------------------ | :--------------------------------- | :--------------------------------- | :------------------------------------------------------ |
 | Send message                    | `SendMessage`                      | `SendMessage`                      | `POST /message:send`                                    |
-| Send streaming message                  | `SendStreamingMessage`             | `SendStreamingMessage`             | `POST /message:stream`                                  |
+| Send streaming message          | `SendStreamingMessage`             | `SendStreamingMessage`             | `POST /message:stream`                                  |
 | Get task                        | `GetTask`                          | `GetTask`                          | `GET /tasks/{id}`                                       |
 | List tasks                      | `ListTasks`                        | `ListTasks`                        | `GET /tasks`                                            |
 | Cancel task                     | `CancelTask`                       | `CancelTask`                       | `POST /tasks/{id}:cancel`                               |

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -53,7 +53,7 @@ graph TB
 
     subgraph L2 ["A2A Operations"]
         direction LR
-        G[Send Message] ~~~ H[Stream Message] ~~~ I[Get Task] ~~~ J[List Tasks] ~~~ K[Cancel Task] ~~~ L[Get Agent Card]
+        G[Send Message] ~~~ H[Send Streaming Message] ~~~ I[Get Task] ~~~ J[List Tasks] ~~~ K[Cancel Task] ~~~ L[Get Agent Card]
     end
 
     subgraph L3 ["Protocol Bindings"]
@@ -213,7 +213,7 @@ The agent MAY return a `Task` for complex processing with status/artifact update
 
 #### 3.1.3. Get Task
 
-Retrieves the current state (including status, artifacts, and optionally history) of a previously initiated task. This is typically used for polling the status of a task initiated with message/send, or for fetching the final state of a task after being notified via a push notification or after a stream has ended.
+Retrieves the current state (including status, artifacts, and optionally history) of a previously initiated task. This is typically used for polling the status of a task initiated with Send Message, or for fetching the final state of a task after being notified via a push notification or after a stream has ended.
 
 **Inputs:**
 
@@ -659,7 +659,7 @@ The A2A protocol provides three complementary mechanisms for clients to receive 
 **Streaming:**
 
 - Real-time delivery of events as they occur
-- Operations: Stream Message ([Section 3.1.2](#312-send-streaming-message)) and Subscribe to Task ([Section 3.1.6](#316-subscribe-to-task))
+- Operations: Send Streaming Message ([Section 3.1.2](#312-send-streaming-message)) and Subscribe to Task ([Section 3.1.6](#316-subscribe-to-task))
 - Low latency, efficient for frequent updates
 - Requires persistent connection support
 - Best for: Interactive applications, real-time dashboards, live progress monitoring
@@ -1162,7 +1162,7 @@ When an agent supports multiple protocols, all supported protocols **MUST**:
 | Functionality                   | JSON-RPC Method                    | gRPC Method                        | REST Endpoint                                           |
 | :------------------------------ | :--------------------------------- | :--------------------------------- | :------------------------------------------------------ |
 | Send message                    | `SendMessage`                      | `SendMessage`                      | `POST /message:send`                                    |
-| Stream message                  | `SendStreamingMessage`             | `SendStreamingMessage`             | `POST /message:stream`                                  |
+| Send Streaming Message                  | `SendStreamingMessage`             | `SendStreamingMessage`             | `POST /message:stream`                                  |
 | Get task                        | `GetTask`                          | `GetTask`                          | `GET /tasks/{id}`                                       |
 | List tasks                      | `ListTasks`                        | `ListTasks`                        | `GET /tasks`                                            |
 | Cancel task                     | `CancelTask`                       | `CancelTask`                       | `POST /tasks/{id}:cancel`                               |

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1162,7 +1162,7 @@ When an agent supports multiple protocols, all supported protocols **MUST**:
 | Functionality                   | JSON-RPC Method                    | gRPC Method                        | REST Endpoint                                           |
 | :------------------------------ | :--------------------------------- | :--------------------------------- | :------------------------------------------------------ |
 | Send message                    | `SendMessage`                      | `SendMessage`                      | `POST /message:send`                                    |
-| Send Streaming Message                  | `SendStreamingMessage`             | `SendStreamingMessage`             | `POST /message:stream`                                  |
+| Send streaming message                  | `SendStreamingMessage`             | `SendStreamingMessage`             | `POST /message:stream`                                  |
 | Get task                        | `GetTask`                          | `GetTask`                          | `GET /tasks/{id}`                                       |
 | List tasks                      | `ListTasks`                        | `ListTasks`                        | `GET /tasks`                                            |
 | Cancel task                     | `CancelTask`                       | `CancelTask`                       | `POST /tasks/{id}:cancel`                               |

--- a/docs/tutorials/python/4-agent-executor.md
+++ b/docs/tutorials/python/4-agent-executor.md
@@ -41,7 +41,7 @@ Let's look at `agent_executor.py`. It defines `HelloWorldAgentExecutor`.
         --8<-- "https://raw.githubusercontent.com/a2aproject/a2a-samples/refs/heads/main/samples/python/agents/helloworld/agent_executor.py:HelloWorldAgentExecutor_execute"
         ```
 
-        When a `message/send` or `message/stream` request comes in (both are handled by `execute` in this simplified executor), the following steps occur:
+        When a `Send Message` or `Send Streaming Message` request comes in (both are handled by `execute` in this simplified executor), the following steps occur:
 
         **Step 1.** The `A2A instance` (server) retrieves the current task from the context. If there is no task in context, then it creates a new task and adds it to the `EventQueue`.
 

--- a/docs/tutorials/python/6-interact-with-server.md
+++ b/docs/tutorials/python/6-interact-with-server.md
@@ -8,7 +8,7 @@ The `test_client.py` script demonstrates how to:
 
 1. Fetch the Agent Card from the server.
 2. Create a client using `create_client`.
-3. Send both non-streaming (`message/send`) and streaming (`message/stream`) requests.
+3. Send both `Send Message` and `Send Streaming Message` requests.
 
 Open a **new terminal window**, activate your virtual environment, and navigate to the `a2a-samples` directory.
 

--- a/docs/tutorials/python/7-streaming-and-multiturn.md
+++ b/docs/tutorials/python/7-streaming-and-multiturn.md
@@ -64,7 +64,7 @@ The `langgraph` example showcases several important A2A concepts:
         ```
 
     - The `CurrencyAgentExecutor` (in `samples/langgraph/agent_executor.py`), when its `execute` method is called by the `DefaultRequestHandler`, interacts with the `RequestContext` which contains the current task (if any).
-    - For `message/send`, the `DefaultRequestHandler` uses the `TaskStore` to persist and retrieve task state across interactions. The response to `message/send` will be a full `Task` object if the agent's execution flow involves multiple steps or results in a persistent task.
+    - For `Send Message`, the `DefaultRequestHandler` uses the `TaskStore` to persist and retrieve task state across interactions. The response to `Send Message` will be a full `Task` object if the agent's execution flow involves multiple steps or results in a persistent task.
     - The `test_client.py`'s `run_single_turn_test` demonstrates getting a `Task` object back and then querying it using `get_task`.
 
 3. **Streaming with `TaskStatusUpdateEvent` and `TaskArtifactUpdateEvent`**:


### PR DESCRIPTION
## Summary
Standardizes the operation names used throughout the spec and Python tutorials so they match the canonical A2A operation names (`Send Message` / `Send Streaming Message`) instead of the older JSON-RPC-style identifiers (`message/send`, `message/stream`) or the inconsistent short form `Stream Message`.
## Changes
- **`docs/specification.md`**
  - Architecture diagram: `Stream Message` → `Send Streaming Message`.
  - Section 3.1.3 (Get Task): `message/send` → `Send Message`.
  - Event delivery section: `Stream Message` → `Send Streaming Message`.
  - Multi-protocol functionality table: `Stream message` → `Send Streaming Message`.
- **`docs/tutorials/python/4-agent-executor.md`**: `message/send` / `message/stream` → `Send Message` / `Send Streaming Message`.
- **`docs/tutorials/python/6-interact-with-server.md`**: same rename in the `test_client.py` description.
- **`docs/tutorials/python/7-streaming-and-multiturn.md`**: `message/send` → `Send Message` in the `CurrencyAgentExecutor` walkthrough.
## Why
The docs previously mixed three different names for the same operations (`message/stream`, `Stream Message`, `SendStreamingMessage`), which was confusing for readers cross-referencing the spec, tutorials, and SDK. This change picks one human-readable form per operation and uses it consistently in prose, while leaving the code-level identifiers (`SendMessage`, `SendStreamingMessage`, `POST /message:stream`, etc.) untouched in the protocol-binding tables.