### PR TITLE
docs(fix): align push notification auth examples with protocol behavior

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -319,7 +319,7 @@ Creates a push notification configuration for a task to receive asynchronous upd
 
 **Inputs:**
 
-{{ proto_to_table("CreateTaskPushNotificationConfig") }}
+{{ proto_to_table("TaskPushNotificationConfig") }}
 
 **Outputs:**
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1640,11 +1640,11 @@ Authorization: Bearer token
     "messageId": "6dbc13b5-bd57-4c2b-b503-24e381b6c8d6"
   },
   "configuration": {
-    "pushNotificationConfig": {
+    "taskPushNotificationConfig": {
       "url": "https://client.example.com/webhook/a2a-notifications",
-      "token": "secure-client-token-for-task-aaa",
       "authentication": {
-        "schemes": ["Bearer"]
+        "scheme": "Bearer",
+        "credentials": "secure-client-token-for-task-aaa"
       }
     }
   }
@@ -1674,9 +1674,8 @@ Content-Type: application/a2a+json
 ```http
 POST /webhook/a2a-notifications HTTP/1.1
 Host: client.example.com
-Authorization: Bearer server-generated-jwt
+Authorization: Bearer secure-client-token-for-task-aaa
 Content-Type: application/a2a+json
-X-A2A-Notification-Token: secure-client-token-for-task-aaa
 
 {
   "statusUpdate": {

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -319,7 +319,7 @@ Creates a push notification configuration for a task to receive asynchronous upd
 
 **Inputs:**
 
-{{ proto_to_table("CreateTaskPushNotificationConfigRequest") }}
+{{ proto_to_table("CreateTaskPushNotificationConfig") }}
 
 **Outputs:**
 


### PR DESCRIPTION
The `authentication` field in the SendMessage's configuration has 2 String fields:

* `scheme`
* `credentials`

The request POSTed to the Webhook pass this authentication info in the `Authorization` HTTP header. The `X-A2A-Notification-Token` header is not required (and is not defined in the spec).

This fixes #1594.