### PR TITLE
docs(extensions): add Tenzro TDIP Binding extension to example list

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -111,8 +111,10 @@ SLF
 SSLv
 Siwach
 Solax
+TDIP
 TJS
 TMDB
+Tenzro
 Tful
 URLTo
 Upserting
@@ -352,6 +354,8 @@ taskslist
 taskssend
 taskstate
 taskstatus
+tdip
+tenzro
 textpart
 threadsafe
 tiangolo

--- a/docs/topics/extensions.md
+++ b/docs/topics/extensions.md
@@ -50,7 +50,7 @@ However, some foreseeable applications include:
 | [Hello World or Timestamp Extension](https://github.com/a2aproject/a2a-samples/tree/main/extensions/timestamp) | A simple extension demonstrating how to augment base A2A types by adding timestamps to the `metadata` field of `Message` and `Artifact` objects (v1). |
 | [Traceability Extension](https://github.com/a2aproject/a2a-samples/tree/main/samples/python/extensions/traceability) | Explore the Python implementation and basic usage of the Traceability Extension (v1). |
 | [Agent Gateway Protocol (AGP) Extension](https://github.com/a2aproject/a2a-samples/tree/main/extensions/agp) | A Core Protocol Layer or Routing Extension that introduces Autonomous Squads (ASq) and routes Intent payloads based on declared Capabilities, enhancing scalability (v1). |
-| [TDIP Binding Extension](https://tenzro.com/a2a/extensions/tdip-binding/v1) | Binds an A2A agent's identity to a Tenzro Decentralized Identity Protocol (TDIP) DID with delegation-scope and runtime spending-policy enforcement, enabling verifiable agent autonomy and per-message authorization for autonomous commerce (v1). |
+| [TDIP Binding Extension](https://tenzro.com/a2a/extensions/tdip-binding/v1) | A Profile Extension that binds an agent's identity to a Tenzro Decentralized Identity Protocol (TDIP) DID with delegation scope and spending policy enforcement, enabling verifiable autonomy and per-message authorization for autonomous commerce (v1). |
 
 ## Extension Governance
 

--- a/docs/topics/extensions.md
+++ b/docs/topics/extensions.md
@@ -50,6 +50,7 @@ However, some foreseeable applications include:
 | [Hello World or Timestamp Extension](https://github.com/a2aproject/a2a-samples/tree/main/extensions/timestamp) | A simple extension demonstrating how to augment base A2A types by adding timestamps to the `metadata` field of `Message` and `Artifact` objects (v1). |
 | [Traceability Extension](https://github.com/a2aproject/a2a-samples/tree/main/samples/python/extensions/traceability) | Explore the Python implementation and basic usage of the Traceability Extension (v1). |
 | [Agent Gateway Protocol (AGP) Extension](https://github.com/a2aproject/a2a-samples/tree/main/extensions/agp) | A Core Protocol Layer or Routing Extension that introduces Autonomous Squads (ASq) and routes Intent payloads based on declared Capabilities, enhancing scalability (v1). |
+| [TDIP Binding Extension](https://tenzro.com/a2a/extensions/tdip-binding/v1) | Binds an A2A agent's identity to a Tenzro Decentralized Identity Protocol (TDIP) DID with delegation-scope and runtime spending-policy enforcement, enabling verifiable agent autonomy and per-message authorization for autonomous commerce (v1). |
 
 ## Extension Governance
 


### PR DESCRIPTION
## Summary

Adds a single-row entry to the **List of Example Extensions** table in `docs/topics/extensions.md` for the **TDIP Binding** A2A extension.

## What is TDIP Binding?

TDIP Binding is a **Profile Extension** (per the A2A taxonomy in §"Scope of Extensions") that binds an A2A agent's identity to a long-lived **Tenzro Decentralized Identity Protocol (TDIP)** DID.

When activated, every A2A `Message` from a TDIP-bound agent carries four metadata fields under the extension URI:

- `…/did` — the agent's `did:tenzro:machine:` DID
- `…/sig` — Ed25519 signature over the JCS-canonicalized message minus the binding fields
- `…/pq_sig` — ML-DSA-65 (FIPS 204) signature over the same preimage (hybrid PQ)
- `…/scope` — optional per-message delegation scope assertion

Receivers run a five-step verification:

1. Resolve the DID via the TDIP registry
2. Recover the controller's public key from the resolved DID Document
3. Verify both Ed25519 and ML-DSA-65 signatures over the JCS preimage
4. Call `DelegationScope::enforce_operation` against the resolved identity
5. Call the runtime `SpendingPolicy::check` against the operation

Failure at any step fails closed with a method-local JSON-RPC error code.

## Why it belongs in the example list

Per the existing **Extension Governance** section, the example table cites third-party extensions hosted at their own URIs (the AGP, Secure Passport, Timestamp, and Traceability rows are all third-party). TDIP Binding follows the same pattern — Tenzro hosts the spec at its own URI and registers a row in the upstream A2A example list for discoverability.

The extension addresses a concrete autonomous-commerce gap not covered by the existing extensions: stable cryptographic identity for agents, verifiable operator delegation, and a runtime spending ceiling that the operator can dial without re-issuing the delegation. This complements (rather than competes with) Secure Passport (caller context) and AGP (routing).

## Spec hosting

The extension URI is **<https://tenzro.com/a2a/extensions/tdip-binding/v1>** (live; HTTP 200). The full specification (sections 1–11: Summary, Motivation, Terminology, Activation, Per-Message Binding, Verification, Examples, Error Codes, Security Considerations, Reference Implementation, References) is hosted at that URI.

## Reference implementation

A working implementation is in [tenzro/tenzro-network](https://github.com/tenzro/tenzro-network) under:

- `crates/tenzro-identity` — TDIP DID resolution, `DelegationScope::enforce_operation`
- `crates/tenzro-agent` — A2A integration, `AgentRuntime::set_spending_policy`
- `crates/tenzro-crypto::composite` — hybrid Ed25519 + ML-DSA-65 signing

A live A2A endpoint is at <https://a2a.tenzro.network> (publishes a TDIP-aware Agent Card at `/.well-known/agent.json`).

## What this PR does NOT change

- No changes to `specification.md` or any normative spec text
- No changes to A2A core types (`Message`, `AgentCard`, etc.)
- No new RPC methods (TDIP Binding is a Profile Extension)
- No changes to A2A SDKs
- Single line added to the existing example table in `docs/topics/extensions.md`
- Four words added to the spelling allow-list (`TDIP`, `Tenzro`, `tdip`, `tenzro`) so the new row passes `Check Spelling`

## Review feedback applied

Gemini's review suggestion has been applied in the second commit:

- The row now leads with **"A Profile Extension that…"** to match the AGP row's categorization style.
- Hyphenation switched to standard form: `delegation scope`, `spending policy`.

## Note for maintainers re: linked-issues check

This is a single-row example-list addition with no underlying issue to close (matching prior partner-list/SDK-list additions like #1729 "Add Rust SDK to list of official SDKs", which was merged with the `no-issue` label). Happy for a maintainer to apply the `no-issue` label so the `Check for Linked Issues` rerun passes; the same pattern was used in #1729, #1702, #1634, and similar merged docs PRs.

## DCO sign-off

Both commits carry `Signed-off-by: Hilal Agil <hilal@tenzro.com>`.

## AI assistance disclosure

Parts of the wording in this PR description and the extension specification were prepared with AI assistance from Claude Code. All technical decisions, the binding design itself, and final wording were reviewed and authored by the human author (Hilal Agil, hilal@tenzro.com). The reference implementation in `tenzro/tenzro-network` was developed independently.

## Checklist

- [x] PR title in Conventional Commits format: `docs(extensions): add Tenzro TDIP Binding extension to example list`
- [x] Single-line addition; structurally identical to sibling rows (Secure Passport, Timestamp, Traceability, AGP)
- [x] Categorization style ("A Profile Extension that…") matches AGP
- [x] Extension URI follows the A2A "Discoverability and Publication" guidance — versioned (`/v1`), under a permanent author-controlled domain, currently resolving with HTTP 200
- [x] Commit `Signed-off-by` (DCO)
- [x] Spelling allow-list updated for new vocabulary
- [x] No changes to `specification.md` or normative spec text
