### PR TITLE
docs: remove deprecated stateTransitionHistory references

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -2154,7 +2154,6 @@ Clients verifying Agent Card signatures **MUST**:
   "capabilities": {
     "streaming": true,
     "pushNotifications": true,
-    "stateTransitionHistory": false,
     "extendedAgentCard": true
   },
   "securitySchemes": {
@@ -3586,7 +3585,7 @@ For **SDK Developers**:
 
 **Rationale:**
 
-All optional features enabling specific operations (`streaming`, `pushNotifications`, `stateTransitionHistory`) reside in `AgentCapabilities`. Moving `extendedAgentCard` achieves:
+All optional features enabling specific operations (`streaming`, `pushNotifications`) reside in `AgentCapabilities`. Moving `extendedAgentCard` achieves:
 
 - Architectural consistency
 - Improved discoverability


### PR DESCRIPTION
stateTransitionHistory shows up in the 1.0 specification documentation, but no longer actually exists in the specification. Remove those references.

This is to resolve https://github.com/a2aproject/A2A/issues/1833