### PR TITLE
docs: add multi-tenancy guide and clarify tenant field semantics

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1998,7 +1998,7 @@ Clients **MUST** follow these rules:
 1. Parse `supportedInterfaces` if present, and select the first supported transport
 2. Prefer earlier entries in the ordered list when multiple options are supported
 3. Use the correct URL for the selected transport
-4. If the selected `AgentInterface` entry has a non-empty `tenant` field, the client **MUST** include that value in the `tenant` field of every request message body sent to that interface
+4. Set the `tenant` field in every request message to exactly the value declared in the selected `AgentInterface` entry (omit the field if `tenant` is not set in that entry)
 
 ### 8.4. Agent Card Signing
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1998,6 +1998,7 @@ Clients **MUST** follow these rules:
 1. Parse `supportedInterfaces` if present, and select the first supported transport
 2. Prefer earlier entries in the ordered list when multiple options are supported
 3. Use the correct URL for the selected transport
+4. If the selected `AgentInterface` entry has a non-empty `tenant` field, the client **MUST** include that value in the `tenant` field of every request message body sent to that interface
 
 ### 8.4. Agent Card Signing
 

--- a/docs/topics/multi-tenancy.md
+++ b/docs/topics/multi-tenancy.md
@@ -9,7 +9,7 @@ when a routing identifier is advertised in an Agent Card.
 ## Overview
 
 A common deployment pattern is to place several agents behind a single host or
-reverse-proxy. From the outside the agents are reachable at the same base URL,
+reverse-proxy. From the outside the agents are reachable at the same domain,
 but each individual agent needs to be distinguished so that requests are
 delivered to the right backend.
 
@@ -21,8 +21,9 @@ Each agent is assigned a distinct URL prefix. The Agent Card for each agent
 advertises its own `url` in `supportedInterfaces`, so clients automatically
 send requests to the correct path.
 
+Agent Card for the "billing" agent:
+
 ```json
-// Agent Card for the "billing" agent
 {
   "name": "Billing Agent",
   "supportedInterfaces": [
@@ -35,8 +36,9 @@ send requests to the correct path.
 }
 ```
 
+Agent Card for the "support" agent:
+
 ```json
-// Agent Card for the "support" agent
 {
   "name": "Support Agent",
   "supportedInterfaces": [
@@ -50,9 +52,8 @@ send requests to the correct path.
 ```
 
 The gateway or reverse-proxy routes `/billing/*` and `/support/*` to the
-appropriate backend without any changes to the A2A protocol messages themselves.
-This is the simplest approach and requires no special client awareness beyond
-reading the Agent Card.
+appropriate backend. This is the simplest approach and requires no special
+client awareness beyond reading the Agent Card.
 
 ### 2. Header-Based Routing
 
@@ -62,7 +63,7 @@ the standard `Authorization` header.
 
 Examples:
 
-- A bearer token whose claims identify the target agent or organisation.
+- A bearer token whose claims identify the target agent or organization.
 - An API key that maps to a particular tenant in the gateway's configuration.
 - A proprietary header such as `X-Agent-ID: billing`.
 
@@ -72,6 +73,13 @@ gateway resolves the target based on the header value. Authentication headers
 are already declared in the Agent Card's `securitySchemes` and `security`
 fields; custom routing headers can be documented as an extension or as
 operator-specific configuration.
+
+!!! note
+    Header-based routing requirements are not discoverable from the Agent Card
+    alone. Clients must obtain the required header values through out-of-band
+    means such as operator documentation or an OAuth token issued during
+    authentication. When routing information needs to be communicated to clients
+    via the Agent Card, prefer the `tenant` field approach described below.
 
 ### 3. Body-Based Routing Using the `tenant` Field
 
@@ -98,14 +106,15 @@ in the `AgentInterface` entry inside `supportedInterfaces`:
 }
 ```
 
-**Client requirement**: If a selected `AgentInterface` entry has a non-empty
-`tenant` field, the client **MUST** include that value in the `tenant` field of
-every request message body sent to that interface. See
+**Client requirement**: The client **MUST** always echo the `tenant` value
+from the selected `AgentInterface` entry back in every request message. If
+the `AgentInterface` does not set `tenant`, the field **MUST** be omitted
+from the request. See
 [Section 8.3.2](../specification.md#832-client-protocol-selection) of the
 specification for the normative rule.
 
 A server MAY use the `tenant` field to represent any routing key that suits its
-deployment — agent identifiers, workspace slugs, organisation IDs, or any other
+deployment — agent identifiers, workspace slugs, organization IDs, or any other
 opaque discriminator.
 
 ## Combining Approaches
@@ -118,7 +127,7 @@ capabilities of the gateway in use.
 
 ## Discovering Multiple Agents
 
-When multiple agents are deployed behind a shared host, each agent **SHOULD**
+When multiple agents are deployed behind a shared domain, each agent **SHOULD**
 have its own Agent Card published at an appropriate location (see
 [Agent Discovery](./agent-discovery.md)). Clients retrieve each agent's card
 independently and use the `supportedInterfaces` information it contains — including

--- a/docs/topics/multi-tenancy.md
+++ b/docs/topics/multi-tenancy.md
@@ -55,31 +55,20 @@ The gateway or reverse-proxy routes `/billing/*` and `/support/*` to the
 appropriate backend. This is the simplest approach and requires no special
 client awareness beyond reading the Agent Card.
 
-### 2. Header-Based Routing
+### 2. Authentication Header-Based Routing
 
-When sub-paths are not convenient (for example, when all agents share the same
-base URL), the gateway can route on a custom HTTP header or on the contents of
-the standard `Authorization` header.
+When multiple agents share the same URL, a gateway can use the authentication
+credentials already present in the request to determine which agent to route to.
+Authentication requirements are declared in the Agent Card's `securitySchemes`
+and `security` fields, making this approach fully discoverable by clients.
 
 Examples:
 
-- A bearer token whose claims identify the target agent or organization.
-- An API key that maps to a particular tenant in the gateway's configuration.
-- A proprietary header such as `X-Agent-ID: billing`.
+- A bearer token whose claims (such as audience or scope) identify the target agent.
+- An API key that maps to a particular agent in the gateway's configuration.
 
-Header-based routing is transparent to the A2A protocol — the agent's
-`supportedInterfaces` entries declare the same URL for each agent, and the
-gateway resolves the target based on the header value. Authentication headers
-are already declared in the Agent Card's `securitySchemes` and `security`
-fields; custom routing headers can be documented as an extension or as
-operator-specific configuration.
-
-!!! note
-    Header-based routing requirements are not discoverable from the Agent Card
-    alone. Clients must obtain the required header values through out-of-band
-    means such as operator documentation or an OAuth token issued during
-    authentication. When routing information needs to be communicated to clients
-    via the Agent Card, prefer the `tenant` field approach described below.
+The gateway inspects the credential and forwards the request to the appropriate
+backend without any changes to the A2A protocol messages themselves.
 
 ### 3. Body-Based Routing Using the `tenant` Field
 

--- a/docs/topics/multi-tenancy.md
+++ b/docs/topics/multi-tenancy.md
@@ -1,0 +1,125 @@
+# Multi-Tenancy and Multi-Agent Routing
+
+A single A2A endpoint can serve multiple agents or tenants. The A2A protocol
+does not prescribe a specific routing implementation — operators are free to
+choose the approach that best fits their infrastructure. This document describes
+the routing mechanisms the protocol supports and the rules clients must follow
+when a routing identifier is advertised in an Agent Card.
+
+## Overview
+
+A common deployment pattern is to place several agents behind a single host or
+reverse-proxy. From the outside the agents are reachable at the same base URL,
+but each individual agent needs to be distinguished so that requests are
+delivered to the right backend.
+
+Three complementary approaches are available:
+
+### 1. URL-Based Routing (Sub-Path)
+
+Each agent is assigned a distinct URL prefix. The Agent Card for each agent
+advertises its own `url` in `supportedInterfaces`, so clients automatically
+send requests to the correct path.
+
+```json
+// Agent Card for the "billing" agent
+{
+  "name": "Billing Agent",
+  "supportedInterfaces": [
+    {
+      "url": "https://agents.example.com/billing",
+      "protocolBinding": "HTTP+JSON",
+      "protocolVersion": "1.0"
+    }
+  ]
+}
+```
+
+```json
+// Agent Card for the "support" agent
+{
+  "name": "Support Agent",
+  "supportedInterfaces": [
+    {
+      "url": "https://agents.example.com/support",
+      "protocolBinding": "HTTP+JSON",
+      "protocolVersion": "1.0"
+    }
+  ]
+}
+```
+
+The gateway or reverse-proxy routes `/billing/*` and `/support/*` to the
+appropriate backend without any changes to the A2A protocol messages themselves.
+This is the simplest approach and requires no special client awareness beyond
+reading the Agent Card.
+
+### 2. Header-Based Routing
+
+When sub-paths are not convenient (for example, when all agents share the same
+base URL), the gateway can route on a custom HTTP header or on the contents of
+the standard `Authorization` header.
+
+Examples:
+
+- A bearer token whose claims identify the target agent or organisation.
+- An API key that maps to a particular tenant in the gateway's configuration.
+- A proprietary header such as `X-Agent-ID: billing`.
+
+Header-based routing is transparent to the A2A protocol — the agent's
+`supportedInterfaces` entries declare the same URL for each agent, and the
+gateway resolves the target based on the header value. Authentication headers
+are already declared in the Agent Card's `securitySchemes` and `security`
+fields; custom routing headers can be documented as an extension or as
+operator-specific configuration.
+
+### 3. Body-Based Routing Using the `tenant` Field
+
+Every A2A request message contains an optional `tenant` field. This is an
+**opaque string** whose value is defined entirely by the server operator; the
+protocol does not impose any format or semantics on it. A gateway or agent
+implementation can inspect this field and forward the request to the appropriate
+backend.
+
+The `tenant` value that a client should use for a particular agent is advertised
+in the `AgentInterface` entry inside `supportedInterfaces`:
+
+```json
+{
+  "name": "Billing Agent",
+  "supportedInterfaces": [
+    {
+      "url": "https://agents.example.com/a2a",
+      "protocolBinding": "HTTP+JSON",
+      "protocolVersion": "1.0",
+      "tenant": "billing"
+    }
+  ]
+}
+```
+
+**Client requirement**: If a selected `AgentInterface` entry has a non-empty
+`tenant` field, the client **MUST** include that value in the `tenant` field of
+every request message body sent to that interface. See
+[Section 8.3.2](../specification.md#832-client-protocol-selection) of the
+specification for the normative rule.
+
+A server MAY use the `tenant` field to represent any routing key that suits its
+deployment — agent identifiers, workspace slugs, organisation IDs, or any other
+opaque discriminator.
+
+## Combining Approaches
+
+The three approaches are not mutually exclusive. For example, a deployment could
+use URL-based routing to distinguish between major product lines and rely on the
+`tenant` field to distinguish individual customers within each product line. The
+appropriate combination depends on the operator's architecture and the
+capabilities of the gateway in use.
+
+## Discovering Multiple Agents
+
+When multiple agents are deployed behind a shared host, each agent **SHOULD**
+have its own Agent Card published at an appropriate location (see
+[Agent Discovery](./agent-discovery.md)). Clients retrieve each agent's card
+independently and use the `supportedInterfaces` information it contains — including
+any `tenant` value — to communicate with the correct agent.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,7 @@ nav:
       - Custom Protocol Bindings: topics/custom-protocol-bindings.md
       - Extension & Binding Governance: topics/extension-and-binding-governance.md
       - Streaming & Asynchronous Operations: topics/streaming-and-async.md
+      - Multi-Tenancy: topics/multi-tenancy.md
       - A2A and MCP: topics/a2a-and-mcp.md
   - Tutorials and Samples:
       - tutorials/index.md

--- a/specification/a2a.proto
+++ b/specification/a2a.proto
@@ -341,7 +341,12 @@ message AgentInterface {
   // easily extended for other protocol bindings. The core ones officially
   // supported are `JSONRPC`, `GRPC` and `HTTP+JSON`.
   string protocol_binding = 2 [(google.api.field_behavior) = REQUIRED];
-  // Tenant ID to be used in the request when calling the agent.
+  // Optional. An opaque string used for routing requests to a specific agent
+  // or tenant when multiple agents are served behind a single A2A endpoint.
+  // When set, clients MUST include this value in the `tenant` field of all
+  // request messages sent to this interface. The server is responsible for
+  // interpreting the value and routing requests accordingly; the protocol
+  // does not define its format or semantics.
   string tenant = 3;
   // The version of the A2A protocol this interface exposes.
   // Use the latest supported minor version per major version.
@@ -462,7 +467,8 @@ message AgentCardSignature {
 
 // A container associating a push notification configuration with a specific task.
 message TaskPushNotificationConfig {
-  // Optional. Tenant ID.
+  // Optional. Opaque routing identifier matching the `tenant` from the
+  // selected `AgentInterface` in the Agent Card.
   string tenant = 1;
   // The push notification configuration details.
   // A unique identifier (e.g. UUID) for this push notification configuration.
@@ -640,7 +646,8 @@ message DeviceCodeOAuthFlow {
 
 // Represents a request for the `SendMessage` method.
 message SendMessageRequest {
-  // Optional. Tenant ID, provided as a path parameter.
+  // Optional. Opaque routing identifier. Must match the `tenant` value from
+  // the selected `AgentInterface` in the Agent Card when that field is set.
   string tenant = 1;
   // The message to send to the agent.
   Message message = 2 [(google.api.field_behavior) = REQUIRED];
@@ -652,7 +659,8 @@ message SendMessageRequest {
 
 // Represents a request for the `GetTask` method.
 message GetTaskRequest {
-  // Optional. Tenant ID, provided as a path parameter.
+  // Optional. Opaque routing identifier. Must match the `tenant` value from
+  // the selected `AgentInterface` in the Agent Card when that field is set.
   string tenant = 1;
   // The resource ID of the task to retrieve.
   string id = 2 [(google.api.field_behavior) = REQUIRED];
@@ -665,7 +673,8 @@ message GetTaskRequest {
 
 // Parameters for listing tasks with optional filtering criteria.
 message ListTasksRequest {
-  // Tenant ID, provided as a path parameter.
+  // Optional. Opaque routing identifier. Must match the `tenant` value from
+  // the selected `AgentInterface` in the Agent Card when that field is set.
   string tenant = 1;
   // Filter tasks by context ID to get tasks from a specific conversation or session.
   string context_id = 2;
@@ -704,7 +713,8 @@ message ListTasksResponse {
 
 // Represents a request for the `CancelTask` method.
 message CancelTaskRequest {
-  // Optional. Tenant ID, provided as a path parameter.
+  // Optional. Opaque routing identifier. Must match the `tenant` value from
+  // the selected `AgentInterface` in the Agent Card when that field is set.
   string tenant = 1;
   // The resource ID of the task to cancel.
   string id = 2 [(google.api.field_behavior) = REQUIRED];
@@ -714,7 +724,8 @@ message CancelTaskRequest {
 
 // Represents a request for the `GetTaskPushNotificationConfig` method.
 message GetTaskPushNotificationConfigRequest {
-  // Optional. Tenant ID, provided as a path parameter.
+  // Optional. Opaque routing identifier. Must match the `tenant` value from
+  // the selected `AgentInterface` in the Agent Card when that field is set.
   string tenant = 1;
   // The parent task resource ID.
   string task_id = 2 [(google.api.field_behavior) = REQUIRED];
@@ -724,7 +735,8 @@ message GetTaskPushNotificationConfigRequest {
 
 // Represents a request for the `DeleteTaskPushNotificationConfig` method.
 message DeleteTaskPushNotificationConfigRequest {
-  // Optional. Tenant ID, provided as a path parameter.
+  // Optional. Opaque routing identifier. Must match the `tenant` value from
+  // the selected `AgentInterface` in the Agent Card when that field is set.
   string tenant = 1;
   // The parent task resource ID.
   string task_id = 2 [(google.api.field_behavior) = REQUIRED];
@@ -734,7 +746,8 @@ message DeleteTaskPushNotificationConfigRequest {
 
 // Represents a request for the `SubscribeToTask` method.
 message SubscribeToTaskRequest {
-  // Optional. Tenant ID, provided as a path parameter.
+  // Optional. Opaque routing identifier. Must match the `tenant` value from
+  // the selected `AgentInterface` in the Agent Card when that field is set.
   string tenant = 1;
   // The resource ID of the task to subscribe to.
   string id = 2 [(google.api.field_behavior) = REQUIRED];
@@ -742,7 +755,8 @@ message SubscribeToTaskRequest {
 
 // Represents a request for the `ListTaskPushNotificationConfigs` method.
 message ListTaskPushNotificationConfigsRequest {
-  // Optional. Tenant ID, provided as a path parameter.
+  // Optional. Opaque routing identifier. Must match the `tenant` value from
+  // the selected `AgentInterface` in the Agent Card when that field is set.
   string tenant = 4;
   // The parent task resource ID.
   string task_id = 1 [(google.api.field_behavior) = REQUIRED];
@@ -756,7 +770,8 @@ message ListTaskPushNotificationConfigsRequest {
 
 // Represents a request for the `GetExtendedAgentCard` method.
 message GetExtendedAgentCardRequest {
-  // Optional. Tenant ID, provided as a path parameter.
+  // Optional. Opaque routing identifier. Must match the `tenant` value from
+  // the selected `AgentInterface` in the Agent Card when that field is set.
   string tenant = 1;
 }
 

--- a/specification/a2a.proto
+++ b/specification/a2a.proto
@@ -467,8 +467,8 @@ message AgentCardSignature {
 
 // A container associating a push notification configuration with a specific task.
 message TaskPushNotificationConfig {
-  // Optional. Opaque routing identifier matching the `tenant` from the
-  // selected `AgentInterface` in the Agent Card.
+  // Optional. Opaque routing identifier. Must match the `tenant` value from
+  // the selected `AgentInterface` in the Agent Card when that field is set.
   string tenant = 1;
   // The push notification configuration details.
   // A unique identifier (e.g. UUID) for this push notification configuration.


### PR DESCRIPTION
## Summary

- Adds a new **Multi-Tenancy** documentation topic (`docs/topics/multi-tenancy.md`) covering how to serve multiple agents behind a single A2A endpoint, with examples of URL-based, header-based, and body-based (`tenant` field) routing strategies.
- Clarifies the `tenant` field in `a2a.proto` — replaces the binding-specific phrase "provided as a path parameter" with accurate, binding-agnostic wording describing it as an opaque routing identifier.
- Adds a normative client rule in spec section 8.3.2: if the selected `AgentInterface` has a non-empty `tenant` field, the client **MUST** include that value in the `tenant` field of every request message body sent to that interface.
- Adds the new topic to the MkDocs navigation.

Fixes #1690
Fixes #1820