### PR TITLE
docs: clarify payment-required extension guidance

### DIFF
--- a/docs/topics/extensions.md
+++ b/docs/topics/extensions.md
@@ -130,6 +130,59 @@ Agents shouldn't mark data-only extensions as required. If a client does not
 request activation of a required extension, or fails to follow its protocol,
 the agent should reject the incoming request with an appropriate error.
 
+## Payment-Required Flows
+
+Payment requirements are usually orthogonal to the core A2A task state machine,
+similar to authentication and authorization. Agents that need payment before
+serving a task can use an extension to advertise how clients should recognize a
+payment challenge and how to retry with payment proof, without adding a new core
+task state.
+
+A payment-required extension specification should define:
+
+- Which transport-level status codes can carry a payment challenge (for example,
+    HTTP `402 Payment Required`), and any equivalent status or error mapping for
+    non-HTTP transports
+- Where the client reads the challenge, such as a response header or
+    extension-scoped task metadata
+- The challenge format, such as an invoice URL, a payment URI, or a challenge
+    envelope for x402-style payments
+- Where the client sends payment proof on retry
+- Whether payment is checked before task creation, or after a task has already
+    entered an interrupted state such as `TASK_STATE_INPUT_REQUIRED` or
+    `TASK_STATE_AUTH_REQUIRED`
+- What receipt or settlement confirmation the agent returns after payment
+
+The extension can be declared in the Agent Card using `params` to make these
+transport details discoverable:
+
+```json
+{
+  "uri": "https://example.com/extensions/payment-required/v1",
+  "description": "Advertises how this agent returns payment challenges",
+  "required": false,
+  "params": {
+    "responseCodes": [402],
+    "challengeHeaders": ["PAYMENT-REQUIRED"],
+    "challengeFormat": "x402",
+    "retryHeaders": ["PAYMENT-SIGNATURE"],
+    "receiptHeaders": ["PAYMENT-RESPONSE"]
+  }
+}
+```
+
+Clients that understand the extension can route payment challenges to a payment
+handler instead of treating them as generic input requests. Clients that do not
+understand the extension still receive the normal transport response or, for a
+required extension, the appropriate extension-support error.
+
+Payment extensions should also document security requirements. At minimum,
+implementations should bind the payment challenge to the requested resource or
+task, amount, currency or asset, recipient, and expiry; validate the returned
+payment proof before producing paid output or side effects; avoid leaking
+sensitive payment metadata; and expose any required challenge or receipt headers
+through CORS when browser clients are expected to participate.
+
 ## Extension Specification
 
 The detailed behavior and structure of an extension are defined by its

--- a/docs/topics/extensions.md
+++ b/docs/topics/extensions.md
@@ -130,41 +130,42 @@ Agents shouldn't mark data-only extensions as required. If a client does not
 request activation of a required extension, or fails to follow its protocol,
 the agent should reject the incoming request with an appropriate error.
 
-## Payment-Required Flows
+## Payment Process Discovery
 
 Payment requirements are usually orthogonal to the core A2A task state machine,
-similar to authentication and authorization. Agents that need payment before
-serving a task can use an extension to advertise how clients should recognize a
-payment challenge and how to retry with payment proof, without adding a new core
-task state.
+similar to authentication and authorization. Rather than adding payment-specific
+rules to the core protocol, an agent can advertise a payment process discovery
+extension. That extension describes how a client discovers the payment process;
+other extensions can then define the details for a specific payment protocol,
+rail, or authorization flow.
 
-A payment-required extension specification should define:
+A payment process discovery extension can define:
 
-- Which transport-level status codes can carry a payment challenge (for example,
-    HTTP `402 Payment Required`), and any equivalent status or error mapping for
-    non-HTTP transports
-- Where the client reads the challenge, such as a response header or
-    extension-scoped task metadata
-- The challenge format, such as an invoice URL, a payment URI, or a challenge
-    envelope for x402-style payments
-- Where the client sends payment proof on retry
-- Whether payment is checked before task creation, or after a task has already
+- Which payment protocols or envelopes the agent supports, such as AP2, x402, or
+    invoice-based flows
+- Which transport-level response codes can indicate that a payment process is
+    needed, and any equivalent status or error mapping for non-HTTP bindings
+- Where the client reads the payment-process challenge, such as response
+    headers, extension-scoped task metadata, or a protocol-specific envelope
+- Where the client sends proof, authorization, or confirmation on retry
+- Whether the process happens before task creation, or after a task has already
     entered an interrupted state such as `TASK_STATE_INPUT_REQUIRED` or
     `TASK_STATE_AUTH_REQUIRED`
 - What receipt or settlement confirmation the agent returns after payment
 
-The extension can be declared in the Agent Card using `params` to make these
-transport details discoverable:
+For example, an agent that supports x402 could declare the discovery extension
+in its Agent Card and point clients to the x402-specific challenge and retry
+fields through `params`:
 
 ```json
 {
-  "uri": "https://example.com/extensions/payment-required/v1",
-  "description": "Advertises how this agent returns payment challenges",
+  "uri": "https://example.com/extensions/payment-process-discovery/v1",
+  "description": "Advertises how clients discover this agent's payment process",
   "required": false,
   "params": {
+    "supportedPaymentProtocols": ["x402"],
     "responseCodes": [402],
     "challengeHeaders": ["PAYMENT-REQUIRED"],
-    "challengeFormat": "x402",
     "retryHeaders": ["PAYMENT-SIGNATURE"],
     "receiptHeaders": ["PAYMENT-RESPONSE"]
   }
@@ -173,15 +174,16 @@ transport details discoverable:
 
 Clients that understand the extension can route payment challenges to a payment
 handler instead of treating them as generic input requests. Clients that do not
-understand the extension still receive the normal transport response or, for a
+understand the extension still receive the normal transport response, or, for a
 required extension, the appropriate extension-support error.
 
-Payment extensions should also document security requirements. At minimum,
-implementations should bind the payment challenge to the requested resource or
-task, amount, currency or asset, recipient, and expiry; validate the returned
-payment proof before producing paid output or side effects; avoid leaking
-sensitive payment metadata; and expose any required challenge or receipt headers
-through CORS when browser clients are expected to participate.
+Payment-specific extensions should document their own security requirements. At
+minimum, implementations should bind payment challenges to the requested
+resource or task, amount, currency or asset, recipient, and expiry; validate the
+returned payment proof or authorization before producing paid output or side
+effects; avoid leaking sensitive payment metadata; and expose any required
+challenge or receipt headers through CORS when browser clients are expected to
+participate.
 
 ## Extension Specification
 


### PR DESCRIPTION
## Summary
- add guidance for modeling payment-required flows as A2A extensions rather than new core task states
- document the discovery metadata an extension should define: response codes, challenge location/format, retry proof location, receipt fields, and task-state timing
- call out security requirements for binding challenges, validating payment proof before paid output, avoiding sensitive metadata leaks, and exposing challenge headers for browser clients

Closes #1815.

## Verification
- npx --yes markdownlint-cli docs/topics/extensions.md --config .github/linters/.markdownlint.json
- git diff --check
- uv run --with-requirements requirements-docs.txt mkdocs build --strict (fails on existing repo warnings unrelated to this change: missing sdk/python/api nav target, existing definitions/spec links, and existing specification anchors)