### PR TITLE
docs: add Rust SDK (a2a-rs) reference to README and update linter workflow

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -18,7 +18,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Load Super Linter Environment Variables into GITHUB_ENV
         run: |

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -18,10 +18,11 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Load Super Linter Environment Variables into GITHUB_ENV
         run: |
-          grep -v '^\\(#.*\\|\\s\\?\\)$' .github/super-linter.env >> "${GITHUB_ENV}"
+          grep -v '^\(#.*\|\s\?\)$' .github/super-linter.env >> "${GITHUB_ENV}"
 
       - name: GitHub Super Linter
         uses: super-linter/super-linter/slim@v8

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ As AI agents become more prevalent, their ability to interoperate is crucial for
     - [🧑‍💻 A2A JS SDK](https://github.com/a2aproject/a2a-js) `npm install @a2a-js/sdk`
     - [☕️ A2A Java SDK](https://github.com/a2aproject/a2a-java) using maven
     - [🔷 A2A .NET SDK](https://github.com/a2aproject/a2a-dotnet) using [NuGet](https://www.nuget.org/packages/A2A) `dotnet add package A2A`
+    - [🦀 A2A Rust SDK](https://github.com/a2aproject/a2a-rs) `cargo add a2a-lf`
 - 🎬 Use our [samples](https://github.com/a2aproject/a2a-samples) to see A2A in action
 
 ## Contributing


### PR DESCRIPTION
## Summary

Add the official Rust SDK ([a2aproject/a2a-rs](https://github.com/a2aproject/a2a-rs)) to the **Getting Started > Use the SDKs** section of the README.

Closes #1862

## Details

The `a2a-rs` workspace is the official Rust implementation of the A2A v1 protocol, maintained under the `a2aproject` GitHub organization. It is published on [crates.io as `a2a-lf`](https://crates.io/crates/a2a-lf) and includes:

- Core protocol types and serde models (`a2a`)
- Async client with transport negotiation (`a2a-client`)
- Server framework built on axum (`a2a-server`)
- gRPC bindings via tonic (`a2a-grpc`)
- Protobuf support (`a2a-pb`)

Despite being an official SDK, it was missing from the README's SDK listing. This PR adds it alongside the existing Python, Go, JS, Java, and .NET SDKs.

## Changes

- `README.md`: Added `🦀 A2A Rust SDK` entry with link to `a2aproject/a2a-rs` and install command `cargo add a2a-lf`

