### PR TITLE
docs(index): restructure homepage information and add missing sections

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -28,6 +28,7 @@ Besen
 Blogs
 CAs
 CLIs
+CTAs
 Camry
 Cjava
 Cpzuhi
@@ -347,6 +348,7 @@ styleguide
 svn
 systemctl
 tablefmt
+tagline
 tagwords
 tasksget
 taskslist

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 <!-- markdownlint-disable MD041 -->
 <div style="text-align: center;">
   <div class="centered-logo-text-group">
-    <img src="docs/assets/a2a-logo-black.svg" alt="Agent2Agent Protocol Logo" width="100">
+    <img src="docs/assets/a2a_logo/color/SVG/a2a_color.svg" alt="Agent2Agent Protocol Logo" width="100">
     <h1>Agent2Agent (A2A) Protocol</h1>
   </div>
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,9 +13,7 @@ hide:
 
 ## What is A2A Protocol?
 
-Welcome to the **official documentation** for the **Agent2Agent (A2A) Protocol**, an open standard designed to enable seamless communication and collaboration between AI agents.
-
-Originally developed by Google and now donated to the Linux Foundation, A2A provides the definitive common language for agent interoperability in a world where agents are built using diverse frameworks and by different vendors.
+Welcome to the **official documentation** for the **Agent2Agent (A2A) Protocol** — an open standard for seamless communication and collaboration between AI agents. In a world where agents are built using diverse frameworks and by different vendors, A2A provides the definitive common language for agent interoperability.
 
 !!! abstract ""
     Build with
@@ -29,7 +27,7 @@ Originally developed by Google and now donated to the Linux Foundation, A2A prov
 
 <div class="grid cards" markdown>
 
-- :material-play-circle:{ .lg .middle } **Video** Intro in <8 min
+- :material-play-circle:{ .lg .middle } **Video** Intro in under 8 min
 
     <iframe class="video-container" src="https://www.youtube.com/embed/Fbr_Solax1w?si=QxPMEEiO5kLr5_0F" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
@@ -79,7 +77,23 @@ Originally developed by Google and now donated to the Linux Foundation, A2A prov
 
 </div>
 
-## Why use the A2A Protocol
+## How A2A Works with MCP
+
+![A2A MCP Graphic](assets/a2a-mcp-readme.png){width="60%"}
+{style="text-align: center; margin-bottom:1em; margin-top:1em;"}
+
+The Model Context Protocol (MCP) and the A2A Protocol are not competitors — they are highly complementary. They solve two different problems and are designed to work together.
+
+- **MCP is for agent-to-tool communication:** it standardizes how an agent connects to its tools, APIs, and resources to get information. See [Model Context Protocol](https://modelcontextprotocol.io/).
+- **A2A is for agent-to-agent communication:** as a universal, decentralized standard, A2A lets independent agents — including those using MCP — discover each other, delegate tasks, and share results.
+
+Use MCP to equip an individual agent with the specific tools it needs to do its job (e.g., access to a GitHub repository or a SQL database). Use A2A to let that specialized agent securely collaborate with other agents across different frameworks.
+
+> Equip the agent with MCP; build the agent's network with A2A.
+
+[:octicons-arrow-right-24: A2A and MCP — deeper dive](./topics/a2a-and-mcp.md)
+
+## Key Features
 
 <div style="text-align:center">
 
@@ -113,18 +127,27 @@ graph LR
 
     Agents interact without needing to share internal memory, tools, or proprietary logic, ensuring security and preserving intellectual property.
 
+- :material-puzzle-outline:{ .lg .middle } **Extensible**
+
+    Add capabilities through formal protocol [extensions and custom bindings](./topics/extension-and-binding-governance.md), governed by a tiered promotion process so the core stays stable.
+
 </div>
 
----
+## What A2A Is Not
 
-## How does A2A work with MCP?
+A2A is a focused protocol. To set expectations, here is what it explicitly does not try to be:
 
-![A2A MCP Graphic](assets/a2a-mcp-readme.png){width="60%"}
-{style="text-align: center; margin-bottom:1em; margin-top:1em;"}
+- **Not an agent development kit** like LangGraph, CrewAI, or ADK for building agentic applications. A2A is the communication layer between agents built with any of these.
+- **Not a sub-agent or tool-call protocol.** A2A does not specify how an agent talks to its own sub-agents or how it invokes tools — use your framework's native primitives, or MCP, for those.
+- **Not a replacement for [MCP](https://modelcontextprotocol.io/).** MCP standardizes agent-to-tool communication; A2A standardizes agent-to-agent communication. They are complementary (see [above](#how-a2a-works-with-mcp)).
+- **Not an interactive messaging app** like Slack, Discord, WhatsApp, or Telegram. A2A is a machine-to-machine protocol for autonomous agents.
 
-A2A and [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) are complementary standards for building robust agentic applications:
+## Governance & Open Source
 
-- **Model Context Protocol (MCP)**: Provides [agent-to-tool communication](https://cloud.google.com/discover/what-is-model-context-protocol). It's a complementary standard that standardizes how an agent connects to its tools, APIs, and resources to get information.
-- **IBM ACP**: [Incorporated into the A2A Protocol](https://github.com/orgs/i-am-bee/discussions/5)
-- **Cisco agntcy**: A framework that provides components to the Internet of Agents with discovery, group communication, identity and observability and leverages A2A and MCP for agent communication and tool calling.
-- **A2A**: Provides agent-to-agent communication. As a universal, decentralized standard, A2A acts as the public internet that allows [ai agents](https://cloud.google.com/discover/what-are-ai-agents)—including those using MCP, or built with frameworks like agntcy—to interoperate, collaborate, and share their findings.
+A2A was originally developed by Google and donated to the Linux Foundation. It is maintained by a Technical Steering Committee with representatives from AWS, Cisco, Google, IBM Research, Microsoft, Salesforce, SAP, and ServiceNow, and supported by a broad community of [partners](./partners.md).
+
+For details on how the project is run, see [`GOVERNANCE.md`](https://github.com/a2aproject/A2A/blob/main/GOVERNANCE.md) and [`MAINTAINERS.md`](https://github.com/a2aproject/A2A/blob/main/MAINTAINERS.md).
+
+## License
+
+The A2A Protocol is licensed under the [Apache License 2.0](https://github.com/a2aproject/A2A/blob/main/LICENSE) and welcomes [contributions](https://github.com/a2aproject/A2A/blob/main/CONTRIBUTING.md) from the community.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,39 +1,58 @@
 ---
 hide:
   - toc
+  - navigation
 ---
 
 <!-- markdownlint-disable MD041 -->
-<div style="text-align: center;">
+<div style="text-align: center;" markdown>
   <div class="centered-logo-text-group">
-    <img src="assets/a2a-logo-black.svg" alt="Agent2Agent Protocol Logo" width="100">
-    <h1>Agent2Agent (A2A) Protocol</h1>
+    <h1><img src="assets/a2a_logo/color/SVG/a2a_color.svg" alt="Agent2Agent Protocol Logo" width="500"></h1>
   </div>
+
+  <p class="hero-tagline">An open protocol enabling communication and interoperability between opaque agentic applications.</p>
+
+  [Get started](./tutorials/python/1-introduction.md){ .md-button .md-button--primary }
+  [Read the spec](./specification.md){ .md-button }
 </div>
 
 ## What is A2A Protocol?
 
-Welcome to the **official documentation** for the **Agent2Agent (A2A) Protocol** — an open standard for seamless communication and collaboration between AI agents. In a world where agents are built using diverse frameworks and by different vendors, A2A provides the definitive common language for agent interoperability.
+The **Agent2Agent (A2A) Protocol** is an open standard for seamless communication and collaboration between AI agents. In a world where agents are built using diverse frameworks and by different vendors, A2A provides the definitive common language for agent interoperability.
 
 !!! abstract ""
     Build with
     **[![ADK Logo](https://google.github.io/adk-docs/assets/agent-development-kit.png){class="twemoji lg middle"} ADK](https://google.github.io/adk-docs/)** _(or any framework)_,
     equip with **[![MCP Logo](https://modelcontextprotocol.io/mcp.png){class="twemoji lg middle"} MCP](https://modelcontextprotocol.io)** _(or any tool)_,
     and communicate with
-    **![A2A Logo](./assets/a2a-logo-black.svg){class="twemoji lg middle"} A2A**,
+    **![A2A Logo](./assets/a2a_logo/icon/color/SVG/a2a_icon_color.svg){class="twemoji lg middle"} A2A**,
     to remote agents, local agents, and humans.
+
+## Key Features
+
+<div class="grid cards" markdown>
+
+- :material-account-group-outline:{ .lg .middle } **Interoperability**
+
+    Connect agents built on different platforms (LangGraph, CrewAI, Semantic Kernel, custom solutions) to create powerful, composite AI systems.
+
+- :material-lan-connect:{ .lg .middle } **Complex Workflows**
+
+    Enable agents to delegate sub-tasks, exchange information, and coordinate actions to solve complex problems that a single agent cannot.
+
+- :material-shield-key-outline:{ .lg .middle } **Secure & Opaque**
+
+    Agents interact without needing to share internal memory, tools, or proprietary logic, ensuring security and preserving intellectual property.
+
+- :material-puzzle-outline:{ .lg .middle } **Extensible**
+
+    Add capabilities through formal protocol [extensions and custom bindings](./topics/extension-and-binding-governance.md), governed by a tiered promotion process so the core stays stable.
+
+</div>
 
 ## Get started with A2A
 
 <div class="grid cards" markdown>
-
-- :material-play-circle:{ .lg .middle } **Video** Intro in under 8 min
-
-    <iframe class="video-container" src="https://www.youtube.com/embed/Fbr_Solax1w?si=QxPMEEiO5kLr5_0F" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-
-- :material-play-circle:{ .lg .middle } **Course** [DeepLearning.AI](https://deeplearning.ai) - Intro to A2A
-
-    [![A2A DeepLearning.AI](https://img.youtube.com/vi/4gYm0Rp7VHc/maxresdefault.jpg)](https://goo.gle/dlai-a2a)
 
 - :material-book-open:{ .lg .middle } **Read the Introduction**
 
@@ -53,9 +72,7 @@ Welcome to the **official documentation** for the **Agent2Agent (A2A) Protocol**
 
     Build your first A2A-compliant agent with our step-by-step Python quickstart.
 
-    [:octicons-arrow-right-24: Python Tutorial](./tutorials/python/1-introduction.md)
-
-    [:octicons-arrow-right-24: Walkthrough with AI Agent Frameworks](https://github.com/holtskinner/A2AWalkthrough)
+    [:octicons-arrow-right-24: Hands-on-Tutorial](./tutorials/python/1-introduction.md)
 
 - :material-code-braces:{ .lg .middle } **Explore Code Samples**
 
@@ -77,12 +94,17 @@ Welcome to the **official documentation** for the **Agent2Agent (A2A) Protocol**
 
     [:fontawesome-brands-rust: Rust](https://github.com/a2aproject/a2a-rust)
 
+- :material-play-circle:{ .lg .middle } **Video** Intro in under 8 min
+
+    <iframe class="video-container" src="https://www.youtube.com/embed/Fbr_Solax1w?si=QxPMEEiO5kLr5_0F" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+- :material-play-circle:{ .lg .middle } **Course** [DeepLearning.AI](https://deeplearning.ai) - Intro to A2A
+
+    [![A2A DeepLearning.AI](https://img.youtube.com/vi/4gYm0Rp7VHc/maxresdefault.jpg)](https://goo.gle/dlai-a2a)
+
 </div>
 
 ## How A2A Works with MCP
-
-![A2A MCP Graphic](assets/a2a-mcp-readme.png){width="60%"}
-{style="text-align: center; margin-bottom:1em; margin-top:1em;"}
 
 The Model Context Protocol (MCP) and the A2A Protocol are not competitors — they are highly complementary. They solve two different problems and are designed to work together.
 
@@ -91,49 +113,26 @@ The Model Context Protocol (MCP) and the A2A Protocol are not competitors — th
 
 Use MCP to equip an individual agent with the specific tools it needs to do its job (e.g., access to a GitHub repository or a SQL database). Use A2A to let that specialized agent securely collaborate with other agents across different frameworks.
 
-> Equip the agent with MCP; build the agent's network with A2A.
-
-[:octicons-arrow-right-24: A2A and MCP — deeper dive](./topics/a2a-and-mcp.md)
-
-## Key Features
-
 <div style="text-align:center">
 
 ```mermaid
-graph LR
+flowchart LR
     User(🧑‍💻 User) <--> ClientAgent(🤖 Client Agent)
-    ClientAgent --> A2A1(**↔️ A2A**) --> RemoteAgent1(🤖 Remote Agent 1)
-    ClientAgent --> A2A2(**↔️ A2A**) --> RemoteAgent2(🤖 Remote Agent 2)
+    RemoteAgent(🤖 Remote Agent)
+    RemoteTool(⚙️ Remote Tool)
+    ClientAgent -- Using <img src="assets/a2a_logo/icon/color/SVG/a2a_icon_color.svg" alt="Agent2Agent Protocol Logo" height="40" width="40"> --> RemoteAgent
+    ClientAgent -- Using <img src="https://modelcontextprotocol.io/mcp.png" alt="Agent2Agent Protocol Logo" height="40" width="40"> --> RemoteTool
+
 
     style User fill:#fdebd0,stroke:#e67e22,stroke-width:2px
     style ClientAgent fill:#d6eaf8,stroke:#3498db,stroke-width:2px
-    style RemoteAgent1 fill:#d6eaf8,stroke:#3498db,stroke-width:2px
-    style RemoteAgent2 fill:#d6eaf8,stroke:#3498db,stroke-width:2px
-    style A2A1 fill:#ebedef,stroke:#909497,stroke-width:2px
-    style A2A2 fill:#ebedef,stroke:#909497,stroke-width:2px
+    style RemoteAgent fill:#d6eaf8,stroke:#3498db,stroke-width:2px
+    style RemoteTool fill:#d6eaf8,stroke:#3498db,stroke-width:2px
 ```
 
 </div>
 
-<div class="grid cards" markdown>
-
-- :material-account-group-outline:{ .lg .middle } **Interoperability**
-
-    Connect agents built on different platforms (LangGraph, CrewAI, Semantic Kernel, custom solutions) to create powerful, composite AI systems.
-
-- :material-lan-connect:{ .lg .middle } **Complex Workflows**
-
-    Enable agents to delegate sub-tasks, exchange information, and coordinate actions to solve complex problems that a single agent cannot.
-
-- :material-shield-key-outline:{ .lg .middle } **Secure & Opaque**
-
-    Agents interact without needing to share internal memory, tools, or proprietary logic, ensuring security and preserving intellectual property.
-
-- :material-puzzle-outline:{ .lg .middle } **Extensible**
-
-    Add capabilities through formal protocol [extensions and custom bindings](./topics/extension-and-binding-governance.md), governed by a tiered promotion process so the core stays stable.
-
-</div>
+[:octicons-arrow-right-24: A2A and MCP — deeper dive](./topics/a2a-and-mcp.md)
 
 ## What A2A Is Not
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,9 +71,11 @@ Welcome to the **official documentation** for the **Agent2Agent (A2A) Protocol**
 
     [:fontawesome-brands-java: Java](https://github.com/a2aproject/a2a-java)
 
-    [:octicons-code-24: C#/.NET](https://github.com/a2aproject/a2a-dotnet)
+    [:material-language-csharp: C#/.NET](https://github.com/a2aproject/a2a-dotnet)
 
     [:fontawesome-brands-golang: Golang](https://github.com/a2aproject/a2a-go)
+
+    [:fontawesome-brands-rust: Rust](https://github.com/a2aproject/a2a-rust)
 
 </div>
 

--- a/docs/stylesheets/custom.css
+++ b/docs/stylesheets/custom.css
@@ -41,6 +41,15 @@
   text-align: left;
 }
 
+/* Hero tagline: sits between the logo and the primary CTAs. */
+.hero-tagline {
+  font-size: 1.25rem;
+  line-height: 1.5;
+  color: var(--md-default-fg-color--light);
+  max-width: 42em;
+  margin: 1em auto 1.75em;
+}
+
 .install-command-container {
   max-width: 600px;
   margin: 2.5em auto;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,8 +79,8 @@ theme:
   font:
     text: Google Sans
     code: Roboto Mono
-  logo: assets/a2a-logo-white.svg
-  favicon: assets/a2a-logo-black.svg
+  logo: assets/a2a_logo/icon/white/SVG/a2a_icon_white.svg
+  favicon: assets/a2a_logo/icon/white/SVG/a2a_icon_white.svg
   icon:
     repo: fontawesome/brands/github
     view: material/pencil-box-multiple

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,40 +20,45 @@ extra:
 # Navigation
 nav:
   - Home: index.md
-  - 🆕 Announcing Version 1.0: announcing-1.0.md
   - Documentation:
       - What is A2A?: topics/what-is-a2a.md
+      - A2A and MCP: topics/a2a-and-mcp.md
       - Core Concepts: topics/key-concepts.md
+      - Life of a Task: topics/life-of-a-task.md
       - Agent Discovery: topics/agent-discovery.md
       - Enterprise Features: topics/enterprise-ready.md
-      - Life of a Task: topics/life-of-a-task.md
-      - Extensions: topics/extensions.md
+      - Streaming & Asynchronous Operations: topics/streaming-and-async.md
+  - Extensions:
+      - Overview: topics/extensions.md
       - Custom Protocol Bindings: topics/custom-protocol-bindings.md
       - Extension & Binding Governance: topics/extension-and-binding-governance.md
-      - Streaming & Asynchronous Operations: topics/streaming-and-async.md
-      - A2A and MCP: topics/a2a-and-mcp.md
-  - Tutorials and Samples:
-      - tutorials/index.md
-      - Quickstart (Python):
-          - Introduction: tutorials/python/1-introduction.md
-          - Setup: tutorials/python/2-setup.md
-          - Agent Skills & Agent Card: tutorials/python/3-agent-skills-and-card.md
-          - Agent Executor: tutorials/python/4-agent-executor.md
-          - Start Server: tutorials/python/5-start-server.md
-          - Interact with Server: tutorials/python/6-interact-with-server.md
-          - Streaming & Multiturn: tutorials/python/7-streaming-and-multiturn.md
-          - Next Steps: tutorials/python/8-next-steps.md
-      - DeepLearning.AI Course: https://goo.gle/dlai-a2a
   - Specification:
       - Overview: specification.md
       - What's New in v1.0: whats-new-v1.md
       - Protocol Definition: definitions.md
-  - SDK Reference:
-      - sdk/index.md
-      - Python: sdk/python/api/index.html
-  - Community: community.md
-  - Partners: partners.md
-  - Roadmap: roadmap.md
+  - Resources:
+      - SDKs:
+          - Overview: sdk/index.md
+          - Python API Reference: sdk/python/api/index.html
+      - Tutorials:
+          - Overview: tutorials/index.md
+          - Quickstart (Python):
+              - Introduction: tutorials/python/1-introduction.md
+              - Setup: tutorials/python/2-setup.md
+              - Agent Skills & Agent Card: tutorials/python/3-agent-skills-and-card.md
+              - Agent Executor: tutorials/python/4-agent-executor.md
+              - Start Server: tutorials/python/5-start-server.md
+              - Interact with Server: tutorials/python/6-interact-with-server.md
+              - Streaming & Multiturn: tutorials/python/7-streaming-and-multiturn.md
+              - Next Steps: tutorials/python/8-next-steps.md
+          - DeepLearning.AI Course: https://goo.gle/dlai-a2a
+  - Community:
+      - community.md
+      - Roadmap: roadmap.md
+      - Partners: partners.md
+  - Blog:
+      - 🆕 Announcing Version 1.0: announcing-1.0.md
+      - Release Notes: https://github.com/a2aproject/A2A/releases
 
 # Repository
 repo_name: a2aproject/A2A
@@ -91,6 +96,7 @@ theme:
       bug: fontawesome/solid/robot
       example: fontawesome/solid/flask
       quote: fontawesome/solid/quote-left
+  language: en
   palette:
     - scheme: default
       primary: indigo
@@ -102,6 +108,7 @@ theme:
     - content.code.copy
     - content.code.select
     - content.tabs.link
+    - navigation.copy
     - navigation.footer
     - navigation.indexes
     - navigation.instant
@@ -109,6 +116,8 @@ theme:
     - navigation.path
     - navigation.top
     - navigation.tracking
+    - navigation.tabs
+    - navigation.sections
     - toc.follow
     - versioning:
         provider: mike
@@ -181,3 +190,4 @@ plugins:
         "tutorials/python/10-next-steps.md": "tutorials/python/8-next-steps.md"
   - mike:
       canonical_version: latest
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,7 +53,7 @@ nav:
               - Next Steps: tutorials/python/8-next-steps.md
           - DeepLearning.AI Course: https://goo.gle/dlai-a2a
   - Community:
-      - community.md
+      - Overview: community.md
       - Roadmap: roadmap.md
       - Partners: partners.md
   - Blog:
@@ -96,7 +96,6 @@ theme:
       bug: fontawesome/solid/robot
       example: fontawesome/solid/flask
       quote: fontawesome/solid/quote-left
-  language: en
   palette:
     - scheme: default
       primary: indigo
@@ -114,10 +113,10 @@ theme:
     - navigation.instant
     - navigation.instant.progress
     - navigation.path
+    - navigation.sections
+    - navigation.tabs
     - navigation.top
     - navigation.tracking
-    - navigation.tabs
-    - navigation.sections
     - toc.follow
     - versioning:
         provider: mike


### PR DESCRIPTION
Reorder homepage to a developer-first reading path:

**What → Try → Compare → Features → Not → Governance → License.**

#### Details:
- Update the Logo
- Promote `## Get started with A2A` directly under the hero.
- Rename `## Why use the A2A Protocol` → `## Key Features`; add an **Extensible** card linking to the extensions governance page.
- Rewrite `## How does A2A work with MCP?` → `## How A2A Works with MCP` as a clean A2A↔MCP comparison. Keep the existing PNG. Add a "See also" link to `topics/a2a-and-mcp.md`.
- Add `## What A2A Is Not` — explicit scope-setting.
- Add `## Governance & Open Source` — moves the LF/TSC paragraph out of the intro; links to `GOVERNANCE.md` and `MAINTAINERS.md`.
- Add `## License` — Apache 2.0 + contributions link.
- Fix `<8 min` → `under 8 min` (the `<` was an HTML-parse hazard).

Closes #1872 

> Please merge changes once approved!

You can preview - https://msampathkumar.github.io/A2A/