### PR TITLE
chore: Update CODEOWNERS to only restrict spec & governance for TSC Approval

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,14 +4,14 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-*                       @a2aproject/a2a-tsc
-docs/                   @a2aproject/a2a-tsc @a2aproject/tech-writing @a2aproject/google-a2a-eng
-scripts/                @a2aproject/a2a-tsc @a2aproject/tech-writing @a2aproject/google-a2a-eng
-.mkdocs.yml             @a2aproject/a2a-tsc @a2aproject/tech-writing @a2aproject/google-a2a-eng
-README.md               @a2aproject/a2a-tsc @a2aproject/tech-writing @a2aproject/google-a2a-eng
-.gemini/                @a2aproject/a2a-tsc @a2aproject/tech-writing @a2aproject/google-a2a-eng
-.mkdocs/                @a2aproject/a2a-tsc @a2aproject/tech-writing @a2aproject/google-a2a-eng
-.github/                @a2aproject/a2a-tsc @a2aproject/tech-writing @a2aproject/google-a2a-eng
+# Fallback owner for everything in the repository
+*                       @a2aproject/a2a-tsc @a2aproject/tech-writing @a2aproject/google-a2a-eng
+
+# Core Specification and Governance (Exclusive TSC ownership, placed at bottom for final override)
+adrs/                   @a2aproject/a2a-tsc
 specification/          @a2aproject/a2a-tsc
 docs/specification.md   @a2aproject/a2a-tsc
 GOVERNANCE.md           @a2aproject/a2a-tsc
+.gitvote.yml            @a2aproject/a2a-tsc
+LICENSE                 @a2aproject/a2a-tsc
+.github/CODEOWNERS      @a2aproject/a2a-tsc

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,9 +5,6 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
 *                       @a2aproject/a2a-tsc
-specification/          @a2aproject/a2a-tsc
-docs/specification.md   @a2aproject/a2a-tsc
-GOVERNANCE.md           @a2aproject/a2a-tsc
 docs/                   @a2aproject/a2a-tsc @a2aproject/tech-writing @a2aproject/google-a2a-eng
 scripts/                @a2aproject/a2a-tsc @a2aproject/tech-writing @a2aproject/google-a2a-eng
 .mkdocs.yml             @a2aproject/a2a-tsc @a2aproject/tech-writing @a2aproject/google-a2a-eng
@@ -15,3 +12,6 @@ README.md               @a2aproject/a2a-tsc @a2aproject/tech-writing @a2aproject
 .gemini/                @a2aproject/a2a-tsc @a2aproject/tech-writing @a2aproject/google-a2a-eng
 .mkdocs/                @a2aproject/a2a-tsc @a2aproject/tech-writing @a2aproject/google-a2a-eng
 .github/                @a2aproject/a2a-tsc @a2aproject/tech-writing @a2aproject/google-a2a-eng
+specification/          @a2aproject/a2a-tsc
+docs/specification.md   @a2aproject/a2a-tsc
+GOVERNANCE.md           @a2aproject/a2a-tsc

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,14 +5,13 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
 *                       @a2aproject/a2a-tsc
-docs/                   @a2aproject/a2a-tsc
-scripts/                @a2aproject/a2a-tsc
 specification/          @a2aproject/a2a-tsc
 docs/specification.md   @a2aproject/a2a-tsc
 GOVERNANCE.md           @a2aproject/a2a-tsc
-.mkdocs/                @a2aproject/a2a-tsc
-.mkdocs.yml             @a2aproject/a2a-tsc
-README.md               @a2aproject/a2a-tsc
-.gemini/                @a2aproject/a2a-tsc
-.mkdocs/                @a2aproject/a2a-tsc
-.github/                @a2aproject/a2a-tsc
+docs/                   @a2aproject/a2a-tsc @a2aproject/tech-writing @a2aproject/google-a2a-eng
+scripts/                @a2aproject/a2a-tsc @a2aproject/tech-writing @a2aproject/google-a2a-eng
+.mkdocs.yml             @a2aproject/a2a-tsc @a2aproject/tech-writing @a2aproject/google-a2a-eng
+README.md               @a2aproject/a2a-tsc @a2aproject/tech-writing @a2aproject/google-a2a-eng
+.gemini/                @a2aproject/a2a-tsc @a2aproject/tech-writing @a2aproject/google-a2a-eng
+.mkdocs/                @a2aproject/a2a-tsc @a2aproject/tech-writing @a2aproject/google-a2a-eng
+.github/                @a2aproject/a2a-tsc @a2aproject/tech-writing @a2aproject/google-a2a-eng


### PR DESCRIPTION
## Summary

- Since https://github.com/a2aproject/A2A/pull/1644 All PRs have required TSC Approval, which has caused bottlenecks in reviewing changes that don't affect the specification.
- This PR adds `@a2aproject/tech-writing` and `@a2aproject/google-a2a-eng` as joint owners alongside `@a2aproject/a2a-tsc`. All general documentation, script, and configuration updates can now be reviewed and approved by any of the three teams.
- Core specification and governance can only be approved by the TSC with strict, exclusive override rules at the bottom of the file.