### PR TITLE
ci: Update guidelines for commit messages

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ Before submitting your PR, there are a few things you can do to make sure it goe
 
 - [ ] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/A2A/blob/main/CONTRIBUTING.md).
 - [ ] Make your Pull Request title follow the Conventional Commits specification and repository rules (e.g., `docs(spec):` for `docs/specification.md`, `docs:` for other docs, and `feat:` / `fix:` reserved for `a2a.proto`). See [CONTRIBUTING.md](https://github.com/a2aproject/A2A/blob/main/CONTRIBUTING.md#conventional-commits) for details.
-- [ ] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format)
+- [ ] Ensure the tests and linter pass (Run `bash scripts/format.sh` from the repository root to format)
 - [ ] Appropriate docs were updated (if necessary)
 
 Fixes #<issue_number_goes_here> 🦕

--- a/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ Thank you for opening a Pull Request!
 Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
 
 - [ ] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/A2A/blob/main/CONTRIBUTING.md).
-- [ ] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
+- [ ] Make your Pull Request title follow the Conventional Commits specification and repository rules (e.g., `docs(spec):` for `docs/specification.md`, `docs:` for other docs, and `feat:` / `fix:` reserved for `a2a.proto`). See [CONTRIBUTING.md](https://github.com/a2aproject/A2A/blob/main/CONTRIBUTING.md#conventional-commits) for details.
 - [ ] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format)
 - [ ] Appropriate docs were updated (if necessary)
 

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -204,6 +204,7 @@ direnv
 dlai
 docstrings
 documentai
+dorny
 dotnet
 eaf
 ebedef

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -15,12 +15,69 @@ jobs:
     permissions:
       pull-requests: read
       statuses: write
-    name: Validate PR Title
+    name: Validate PR Title & Repository Rules
     runs-on: ubuntu-latest
     steps:
-      - name: semantic-pull-request
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Filter Changed Files
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            proto:
+              - 'specification/a2a.proto'
+            spec:
+              - 'docs/specification.md'
+
+      # Step 1: If docs/specification.md is modified (and proto is not), require docs(spec):
+      - name: Validate PR Title for Core Spec Changes
+        if: steps.filter.outputs.spec == 'true' && steps.filter.outputs.proto == 'false'
         uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           validateSingleCommit: false
+          types: |
+            docs
+          scopes: |
+            spec
+          requireScope: true
+
+      # Step 2: If protocol definition (proto) is modified, require feat/fix/chore/refactor
+      - name: Validate PR Title for Protocol Changes
+        if: steps.filter.outputs.proto == 'true'
+        uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          validateSingleCommit: false
+          types: |
+            feat
+            fix
+            chore
+            refactor
+          disallowScopes: |
+            spec
+
+      # Step 3: General fallback for all other changes (non-core docs, CI, scripts, tools, etc.)
+      - name: Validate PR Title for General Changes
+        if: steps.filter.outputs.proto == 'false' && steps.filter.outputs.spec == 'false'
+        uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          validateSingleCommit: false
+          types: |
+            docs
+            chore
+            ci
+            test
+            refactor
+            style
+            perf
+            build
+            revert
+          disallowScopes: |
+            spec

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Filter Changed Files
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       pull-requests: read
       statuses: write
-    name: Validate PR Title & Repository Rules
+    name: Validate PR Title
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,27 +77,14 @@ We use [markdownlint](https://github.com/igorshubovych/markdownlint-cli) for for
 
 ### Conventional Commits
 
-We follow the [Conventional Commits](https://www.conventionalcommits.org/) specification for our commit messages and Pull Request titles. This helps us automate our release process, generate changelogs, and maintain high standards.
+We follow the [Conventional Commits](https://www.conventionalcommits.org/) specification for our commit messages and PR titles to automate releases. We enforce the following rules depending on which files are changed:
 
-To align with how our releases are automated, we enforce the following rules for PR titles and commit prefixes depending on which files are modified:
+- **Core Specification (`docs(spec):`)**: Use for changes to the core specification (`docs/specification.md`).
+- **General Documentation (`docs:`)**: Use for other files under `docs/` (without the `spec` scope).
+- **Protocol Updates (`feat:` / `fix:`)**: Reserved exclusively for changes to the protocol definition (`specification/a2a.proto`).
 
-1. **Core Specification Edits (`docs(spec):`)**
-   - **Target**: Modifications to the human-readable core specification document (`docs/specification.md`).
-   - **Prefix**: Must use the `docs(spec):` prefix (e.g., `docs(spec): clarify handshake sequence`).
-   - **Rationale**: Since these changes clarify or refine the specification text without modifying the machine-readable protocol definition, they should be clearly marked as specification changes but must not trigger a new release.
-
-2. **General Documentation (`docs:`)**
-   - **Target**: General docs files under the `docs/` directory other than the core specification (e.g., guides, definitions, FAQs).
-   - **Prefix**: Must use the `docs:` prefix without the `spec` scope (e.g., `docs: update setup instructions`).
-   - **Rationale**: Keeps documentation changes separate from specification and code updates, preventing unnecessary release bumps.
-
-3. **Protocol updates (`feat:` / `fix:`)**
-   - **Target**: Functional updates to the machine-readable protocol definition (`specification/a2a.proto`).
-   - **Prefix**: Reserved exclusively for changes that include modifications to `specification/a2a.proto` (e.g., `feat: add encryption handshake fields` or `fix: correct typo in service error codes`).
-   - **Rationale**: Commits starting with `feat:` or `fix:` trigger automated protocol releases and version bumps (via `release-please`). Pure documentation edits must not use these prefixes to avoid accidental protocol releases.
-
-> [!NOTE]
-> If a documentation edit defines a change in how the protocol is actually used, **it must be accompanied by a corresponding update in the protocol definition** (even if it's just updating comments/descriptions in `specification/a2a.proto`). This ensures that the machine-readable schema and human-readable documentation remain synchronized, and correctly triggers a new package release.
+> [!TIP]
+> If a documentation change alters how the protocol should be used, update the `.proto` file as well (even just its comments) so that a new protocol release is triggered.
 
 ## Contribution Process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,27 @@ We use [markdownlint](https://github.com/igorshubovych/markdownlint-cli) for for
 
 ### Conventional Commits
 
-We follow the [Conventional Commits](https://www.conventionalcommits.org/) specification for our commit messages. This helps us automate our release process and maintain a clear changelog.
+We follow the [Conventional Commits](https://www.conventionalcommits.org/) specification for our commit messages and Pull Request titles. This helps us automate our release process, generate changelogs, and maintain high standards.
+
+To align with how our releases are automated, we enforce the following rules for PR titles and commit prefixes depending on which files are modified:
+
+1. **Core Specification Edits (`docs(spec):`)**
+   - **Target**: Modifications to the human-readable core specification document (`docs/specification.md`).
+   - **Prefix**: Must use the `docs(spec):` prefix (e.g., `docs(spec): clarify handshake sequence`).
+   - **Rationale**: Since these changes clarify or refine the specification text without modifying the machine-readable protocol definition, they should be clearly marked as specification changes but must not trigger a new release.
+
+2. **General Documentation (`docs:`)**
+   - **Target**: General docs files under the `docs/` directory other than the core specification (e.g., guides, definitions, FAQs).
+   - **Prefix**: Must use the `docs:` prefix without the `spec` scope (e.g., `docs: update setup instructions`).
+   - **Rationale**: Keeps documentation changes separate from specification and code updates, preventing unnecessary release bumps.
+
+3. **Protocol updates (`feat:` / `fix:`)**
+   - **Target**: Functional updates to the machine-readable protocol definition (`specification/a2a.proto`).
+   - **Prefix**: Reserved exclusively for changes that include modifications to `specification/a2a.proto` (e.g., `feat: add encryption handshake fields` or `fix: correct typo in service error codes`).
+   - **Rationale**: Commits starting with `feat:` or `fix:` trigger automated protocol releases and version bumps (via `release-please`). Pure documentation edits must not use these prefixes to avoid accidental protocol releases.
+
+> [!NOTE]
+> If a documentation edit defines a change in how the protocol is actually used, **it must be accompanied by a corresponding update in the protocol definition** (even if it's just updating comments/descriptions in `specification/a2a.proto`). This ensures that the machine-readable schema and human-readable documentation remain synchronized, and correctly triggers a new package release.
 
 ## Contribution Process
 


### PR DESCRIPTION
- Reserves release keyworks `feat`/`fix` for specification proto changes
- Updates conventional-commits Action to validate specific titles.