### PR TITLE
fix: use POST for SubscribeToTask binding

### DIFF
--- a/specification/a2a.proto
+++ b/specification/a2a.proto
@@ -75,9 +75,11 @@ service A2AService {
   // Returns `UnsupportedOperationError` if the task is already in a terminal state (completed, failed, canceled, rejected).
   rpc SubscribeToTask(SubscribeToTaskRequest) returns (stream StreamResponse) {
     option (google.api.http) = {
-      get: "/tasks/{id=*}:subscribe"
+      post: "/tasks/{id=*}:subscribe"
+      body: "*"
       additional_bindings: {
-        get: "/{tenant}/tasks/{id=*}:subscribe"
+        post: "/{tenant}/tasks/{id=*}:subscribe"
+        body: "*"
       }
     };
   }


### PR DESCRIPTION
## Summary

- Change the `SubscribeToTask` HTTP annotation from `GET /tasks/{id}:subscribe` to `POST /tasks/{id}:subscribe`.
- Apply the same change to the tenant-scoped binding.
- Add `body: "*"` to both custom POST bindings so the proto passes the API linter.

## Changes

- Updated the default `SubscribeToTask` REST binding to use `post`.
- Updated the tenant-scoped `SubscribeToTask` REST binding to use `post`.
- Added `body: "*"` to both custom POST bindings, matching the API linter requirement for custom POST methods.

## Why

The protocol documentation already lists Subscribe to task as `POST /tasks/{id}:subscribe` in the REST method mapping and task operations sections. The proto annotation still used `get`, so generated REST bindings could disagree with the published specification.

## Scope

This only updates the `SubscribeToTask` HTTP binding in `specification/a2a.proto`. It does not change the request message shape or any other task operation.

Fixes #1819
Fixes: #1574

## Verification

```bash
(cd specification && buf dep update && buf export buf.build/googleapis/googleapis --output=.googleapis)
api-linter --config specification/.api-linter.yaml --output-format github --set-exit-status --proto-path specification --proto-path specification/.googleapis specification/a2a.proto
protoc -I specification -I specification/.googleapis --descriptor_set_out=/tmp/a2a.pb specification/a2a.proto
./scripts/build_docs.sh
```
