### PR TITLE
docs: add A2A & generative UI hackathon banner

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1,5 +1,6 @@
 Abhimanyu
 lfx
+luma
 Petschulat
 SFDC
 Siwach

--- a/.mkdocs/overrides/main.html
+++ b/.mkdocs/overrides/main.html
@@ -1,16 +1,18 @@
 {% extends "base.html" %}
 
 {% block announce %}
-  <p class="md-banner__hackathon">
+  <p>
     <span>Sign up to the <strong>A2A and generative UI hackathon</strong> in London on Saturday 13th June!</span>
     <a href="https://luma.com/a2a-and-generative-ui-hackathon" class="md-button">
       Sign up
     </a>
   </p>
   <!--
-  Join the new DeepLearning.AI short course: <strong>A2A: The Agent2Agent Protocol</strong>!
-  <a href="https://goo.gle/dlai-a2a" class="md-button">
-    Enroll for free
-  </a>
+  <p>
+    <span>Join the new DeepLearning.AI short course: <strong>A2A: The Agent2Agent Protocol</strong>!</span>
+    <a href="https://goo.gle/dlai-a2a" class="md-button">
+      Enroll for free
+    </a>
+  </p>
   -->
 {% endblock %}

--- a/.mkdocs/overrides/main.html
+++ b/.mkdocs/overrides/main.html
@@ -1,8 +1,16 @@
 {% extends "base.html" %}
 
 {% block announce %}
+  <p class="md-banner__hackathon">
+    <span>Sign up to the <strong>A2A and generative UI hackathon</strong> in London on Saturday 13th June!</span>
+    <a href="https://luma.com/a2a-and-generative-ui-hackathon" class="md-button">
+      Sign up
+    </a>
+  </p>
+  <!--
   Join the new DeepLearning.AI short course: <strong>A2A: The Agent2Agent Protocol</strong>!
   <a href="https://goo.gle/dlai-a2a" class="md-button">
     Enroll for free
   </a>
+  -->
 {% endblock %}

--- a/docs/stylesheets/custom.css
+++ b/docs/stylesheets/custom.css
@@ -70,15 +70,18 @@
   line-height: 1.4;
 }
 
-/* stylelint-disable selector-class-pattern -- Material uses BEM `__` class names */
-.md-banner__inner:has(.md-banner__hackathon) {
+/* Announcement bar: right-align the call-to-action button and vertically
+   center both it and the dismiss icon. Each announcement is wrapped in a
+   <p>. Material uses BEM `__` class names, hence the stylelint exception. */
+/* stylelint-disable selector-class-pattern */
+.md-banner__inner {
   display: grid;
   grid-template-columns: 1fr auto;
   column-gap: 0.8em;
   align-items: center;
 }
 
-.md-banner__hackathon {
+.md-banner__inner > p {
   grid-column: 1;
   display: flex;
   align-items: center;
@@ -86,12 +89,12 @@
   margin: 0;
 }
 
-.md-banner__hackathon .md-button {
+.md-banner__inner .md-button {
   margin-left: auto;
   padding: 0.2em 0.6em;
 }
 
-.md-banner__inner:has(.md-banner__hackathon) .md-banner__button {
+.md-banner__button {
   grid-column: 2;
   grid-row: 1 / -1;
   align-self: center;

--- a/docs/stylesheets/custom.css
+++ b/docs/stylesheets/custom.css
@@ -70,10 +70,30 @@
   line-height: 1.4;
 }
 
-.announce .md-button {
-  font-size: 0.8em;
-  padding: 0.3em 1em;
-  margin-left: 0.5em;
+.md-banner__inner:has(.md-banner__hackathon) {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  column-gap: 0.8em;
+  align-items: center;
+}
+
+.md-banner__hackathon {
+  grid-column: 1;
+  display: flex;
+  align-items: center;
+  gap: 1em;
+  margin: 0;
+}
+
+.md-banner__hackathon .md-button {
+  margin-left: auto;
+  padding: 0.2em 0.6em;
+}
+
+.md-banner__inner:has(.md-banner__hackathon) .md-banner__button {
+  grid-column: 2;
+  grid-row: 1 / -1;
+  align-self: center;
 }
 
 h1#agent2agent-a2a-protocol {

--- a/docs/stylesheets/custom.css
+++ b/docs/stylesheets/custom.css
@@ -70,6 +70,7 @@
   line-height: 1.4;
 }
 
+/* stylelint-disable selector-class-pattern -- Material uses BEM `__` class names */
 .md-banner__inner:has(.md-banner__hackathon) {
   display: grid;
   grid-template-columns: 1fr auto;
@@ -95,6 +96,7 @@
   grid-row: 1 / -1;
   align-self: center;
 }
+/* stylelint-enable selector-class-pattern */
 
 h1#agent2agent-a2a-protocol {
   display: none;


### PR DESCRIPTION
## Summary

Add an announcement banner promoting the **A2A and generative UI hackathon** in London on Saturday 13th June, linking to the [Luma signup page](https://luma.com/a2a-and-generative-ui-hackathon).

The existing DeepLearning.AI course banner is commented out for now so a single, focused announcement is shown for the next 10 days. After the hackathon, removing the hackathon `<p>` and uncommenting the original course banner restores the previous state exactly — see "Future state" below.

## Changes

Only two files are touched:

- **`.mkdocs/overrides/main.html`** — add a new `<p class="md-banner__hackathon">` for the hackathon announcement; comment out the previous course-banner content.
- **`docs/stylesheets/custom.css`** — replace the previously dead `.announce .md-button` rule with a `:has(.md-banner__hackathon)`-scoped layout that right-aligns the announcement button (with smaller padding) and vertically centers the dismiss icon.

## Before / After

### Before (current production banner)

<img width="1292" height="64" alt="Screenshot 2026-06-03 at 18 04 35" src="https://github.com/user-attachments/assets/49b259d1-09b8-43f4-910b-a972d9593b68" />

### After (this PR)

<img width="1292" height="52" alt="Screenshot 2026-06-03 at 18 07 51" src="https://github.com/user-attachments/assets/70ca84fa-c9be-47ae-b692-4f882bfe985e" />

## Future state (after the hackathon)

The CSS is scoped via `:has(.md-banner__hackathon)`, so when the hackathon paragraph is later removed and the course banner is uncommented, **all custom styling becomes inert** and the course banner renders exactly as it did before this PR (default Material styling, big inline "Enroll for free" button, ✕ floated top-right). Verified locally by reverting the template to its pre-PR contents — the page rendered identically to the current production site.

## Dismiss behaviour

Material's `announce.dismiss` keys dismissal off a hash of the announce block's HTML, so users who previously dismissed the course banner will still see the new hackathon banner (different content → different hash → different dismissal state). The same applies when the course banner is reinstated after the hackathon.

## Test plan

- [x] Build the docs locally with `./scripts/build_docs.sh` — no warnings introduced.
- [x] Serve with `mkdocs serve` and verify the hackathon banner renders with the button right-aligned, vertically centered, and the ✕ vertically centered with a small gap (see "After" screenshot).
- [x] Simulate the post-hackathon state by reverting `.mkdocs/overrides/main.html` to its pre-PR contents; confirm the page renders identically to the current production site (default Material banner styling).
- [x] Confirm `custom.css` changes don't affect any other `.md-button` on the site — the new selectors are all scoped under `.md-banner__inner:has(.md-banner__hackathon)` / `.md-banner__hackathon`.