### PR TITLE
docs: escape timestamp format to prevent emoji rendering in `whats-new-v1`

### DIFF
--- a/docs/whats-new-v1.md
+++ b/docs/whats-new-v1.md
@@ -214,7 +214,7 @@ The v1.0 release focuses on four major themes:
 - ✅ `state`: **BREAKING** - Enum values changed from lowercase to `SCREAMING_SNAKE_CASE` with `TASK_STATE_` prefix
     - v0.3.0: `"submitted"`, `"working"`, `"completed"`, `"failed"`, `"canceled"`, `"rejected"`, `"input-required"`, `"auth-required"`
     - v1.0: `"TASK_STATE_SUBMITTED"`, `"TASK_STATE_WORKING"`, `"TASK_STATE_COMPLETED"`, `"TASK_STATE_FAILED"`, `"TASK_STATE_CANCELED"`, `"TASK_STATE_REJECTED"`, `"TASK_STATE_INPUT_REQUIRED"`, `"TASK_STATE_AUTH_REQUIRED"`
-- ✅ `timestamp`: Now explicitly ISO 8601 UTC with millisecond precision (YYYY-MM-DDTHH:mm:ss.sssZ)
+- ✅ `timestamp`: Now explicitly ISO 8601 UTC with millisecond precision (`YYYY-MM-DDTHH:mm:ss.sssZ`)
 
 **Removed Fields:**
 
@@ -586,7 +586,7 @@ v1.0 introduces several new formal dependencies on industry-standard specificati
 
 - **Purpose:** Timestamp format standard
 - **Usage:** All timestamp fields (createdAt, lastModified, timestamp)
-- **Impact:** Explicit format requirement: UTC with millisecond precision (YYYY-MM-DDTHH:mm:ss.sssZ)
+- **Impact:** Explicit format requirement: UTC with millisecond precision (`YYYY-MM-DDTHH:mm:ss.sssZ`)
 
 ### Existing Dependencies (Retained from v0.3.0)
 


### PR DESCRIPTION
Closes: #1911 

In `docs/whats-new-v1.md`, the ISO 8601 timestamp pattern `YYYY-MM-DDTHH:mm:ss.sssZ` was written without backticks. The `:mm:` part gets interpreted as an emoji shortcode by mkdocs-material and renders as the 
Myanmar flag (🇲🇲).

<img width="1226" height="822" alt="스크린샷 2026-06-04 오후 3 24 27" src="https://github.com/user-attachments/assets/b00e312f-25f9-4f91-b5c6-a10bda887b31" />
