### PR TITLE
docs: add validation tools guide

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -63,6 +63,7 @@ Hackathon
 IFdvcmxk
 IMPCUk
 INR
+ITK
 Ikp
 Imh
 Imprd
@@ -109,6 +110,7 @@ SFDC
 SLAs
 SLF
 SSLv
+SUT
 Siwach
 Solax
 TJS
@@ -260,6 +262,7 @@ inbox
 inmemory
 ipynb
 iss
+itk
 jherr
 jku
 jqlang
@@ -344,6 +347,7 @@ sss
 stateclass
 stephenh
 styleguide
+sut
 svn
 systemctl
 tablefmt

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -19,7 +19,12 @@ The TSC looks to streamline opportunities for contribution through [A2A extensio
 
 ### Validation
 
-As the A2A ecosystem matures, it becomes critical for the A2A community to have tools to validate their agents. The community has launched two efforts to help with validation. Learn more about [A2A Inspector](https://github.com/a2aproject/a2a-inspector) and the [A2A Protocol Technology Compatibility Kit](https://github.com/a2aproject/a2a-tck) (TCK).
+As the A2A ecosystem matures, it becomes critical for the A2A community to have
+tools to validate agents and SDK interoperability. Learn more about the
+[A2A Inspector](https://github.com/a2aproject/a2a-inspector), the
+[A2A Protocol Technology Compatibility Kit](https://github.com/a2aproject/a2a-tck)
+(TCK), and the [A2A Integration Test Kit](https://github.com/a2aproject/a2a-itk)
+(ITK) in the [Validation Tools](validation-tools.md) guide.
 
 ### SDKs
 

--- a/docs/validation-tools.md
+++ b/docs/validation-tools.md
@@ -1,0 +1,142 @@
+# Validation Tools
+
+The A2A project provides validation tools for different stages of agent and SDK
+development. Use the Inspector for interactive debugging, the Technology
+Compatibility Kit (TCK) for protocol conformance, and the Integration Test Kit
+(ITK) for cross-SDK integration testing.
+
+| Tool | Best for | Repository |
+| :--- | :------- | :--------- |
+| A2A Inspector | Inspecting and debugging an A2A server manually | [a2a-inspector](https://github.com/a2aproject/a2a-inspector) |
+| A2A TCK | Validating one A2A implementation against protocol requirements | [a2a-tck](https://github.com/a2aproject/a2a-tck) |
+| A2A ITK | Validating interoperability across SDKs, versions, and transports | [a2a-itk](https://github.com/a2aproject/a2a-itk) |
+
+## A2A Inspector
+
+The A2A Inspector is a web application for exploring a running A2A server. It is
+useful while building or debugging an agent because it can connect to a local
+agent, fetch and display the Agent Card, run basic Agent Card validation, send
+messages through a chat interface, and show raw JSON-RPC traffic in a debug
+console.
+
+Use the Inspector when you want to:
+
+- Confirm that an agent is reachable from a browser-based tool.
+- Review the Agent Card returned by the server.
+- Send exploratory messages without writing a custom client.
+- Inspect request and response payloads during development.
+
+The Inspector is not a full conformance suite. For protocol-level validation,
+use the TCK.
+
+## Technology Compatibility Kit
+
+The A2A Technology Compatibility Kit validates a single A2A implementation,
+called the System Under Test (SUT), against A2A protocol requirements. It can run
+against the transports declared in the agent's `supportedInterfaces` and
+currently supports gRPC, JSON-RPC, and HTTP+JSON.
+
+Use the TCK when you want to:
+
+- Validate that an A2A server implements required protocol behavior.
+- Exercise a specific transport such as `grpc`, `jsonrpc`, or `http_json`.
+- Generate compatibility reports for local review or CI systems.
+- Focus validation on requirement levels such as `must`, `should`, or `may`.
+
+### Running the TCK
+
+Install and run the TCK from its repository:
+
+```bash
+git clone https://github.com/a2aproject/a2a-tck.git
+cd a2a-tck
+
+uv venv
+source .venv/bin/activate
+uv pip install -e .
+
+./run_tck.py --sut-host http://localhost:9999
+```
+
+Run only one transport:
+
+```bash
+./run_tck.py --sut-host http://localhost:9999 --transport grpc
+```
+
+Run only a specific requirement level:
+
+```bash
+./run_tck.py --sut-host http://localhost:9999 --level must
+```
+
+The TCK writes reports to the `reports/` directory, including machine-readable
+compatibility output, an HTML compatibility report, a pytest HTML report, and
+JUnit XML for CI integration.
+
+## Integration Test Kit
+
+The A2A Integration Test Kit validates interoperability across SDK
+implementations, SDK versions, and transport combinations. It uses multi-hop
+agent traversal scenarios to verify that messages can move through a cluster of
+agents using transports such as JSON-RPC, gRPC, and HTTP+JSON.
+
+Use the ITK when you want to:
+
+- Test an SDK against stable reference SDK implementations.
+- Validate cross-version behavior before merging SDK changes.
+- Exercise multi-agent routing across different transport protocols.
+- Run PR-focused or nightly integration suites.
+- Publish recurring integration results to the ITK dashboard.
+
+### Running the ITK
+
+Install the ITK from its repository and run the stable integration suite:
+
+```bash
+git clone https://github.com/a2aproject/a2a-itk.git
+cd a2a-itk
+
+uv run run_tests.py
+```
+
+The ITK repository includes stable reference agents, scenario definitions,
+runner scripts, a mock notification server, and a dashboard for compatibility
+matrix results.
+
+## Choosing a Tool
+
+Use the tools together as the implementation matures:
+
+1. Use the Inspector during development to verify that the server is reachable
+   and that request and response payloads look correct.
+2. Run the TCK when the server is ready for protocol validation.
+3. Add ITK coverage when an SDK or framework needs cross-implementation
+   compatibility checks.
+
+The TCK and ITK are complementary. The TCK asks whether one implementation
+conforms to A2A protocol requirements. The ITK asks whether multiple
+implementations work together across versions, transports, and agent traversal
+patterns.
+
+## CI and SDK Integration
+
+For CI pipelines, start with the smallest validation scope that catches the
+failure mode you care about:
+
+- Agent implementation repositories can run the TCK against a local test server
+    and publish the generated `reports/` artifacts.
+- SDK repositories can run ITK scenarios against a "current" SDK checkout and
+    stable reference SDK agents.
+- Nightly pipelines can run broader ITK matrices and publish metrics for the
+    centralized dashboard.
+
+When integrating ITK into an SDK repository, provide:
+
+- An instruction-handling test agent for the SDK.
+- Scenario definitions for PR and nightly validation.
+- A runner script that checks out the ITK revision, mounts the SDK workspace,
+    starts the required agent cluster, and verifies the result artifacts.
+
+See the ITK repository for production integration examples in the Python and Go
+SDK repositories.

--- a/docs/validation-tools.md
+++ b/docs/validation-tools.md
@@ -125,18 +125,18 @@ For CI pipelines, start with the smallest validation scope that catches the
 failure mode you care about:
 
 - Agent implementation repositories can run the TCK against a local test server
-    and publish the generated `reports/` artifacts.
+  and publish the generated `reports/` artifacts.
 - SDK repositories can run ITK scenarios against a "current" SDK checkout and
-    stable reference SDK agents.
+  stable reference SDK agents.
 - Nightly pipelines can run broader ITK matrices and publish metrics for the
-    centralized dashboard.
+  centralized dashboard.
 
 When integrating ITK into an SDK repository, provide:
 
 - An instruction-handling test agent for the SDK.
 - Scenario definitions for PR and nightly validation.
 - A runner script that checks out the ITK revision, mounts the SDK workspace,
-    starts the required agent cluster, and verifies the result artifacts.
+  starts the required agent cluster, and verifies the result artifacts.
 
 See the ITK repository for production integration examples in the Python and Go
 SDK repositories.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
       - What's New in v1.0: whats-new-v1.md
       - Protocol Definition: definitions.md
   - Resources:
+      - Validation Tools: validation-tools.md
       - SDKs:
           - Overview: sdk/index.md
           - Python API Reference: sdk/python/api/index.html
@@ -190,4 +191,3 @@ plugins:
         "tutorials/python/10-next-steps.md": "tutorials/python/8-next-steps.md"
   - mike:
       canonical_version: latest
-


### PR DESCRIPTION
Title:
docs: add validation tools guide

Body:
## Summary

- Add a new Validation Tools guide covering A2A Inspector, TCK, and ITK.
- Explain when to use each tool and how they fit into agent, protocol, SDK, and CI validation workflows.
- Add the new guide to the Resources navigation and update the roadmap validation section to include ITK.

## Why

Users need a clearer entry point for understanding what TCK and ITK are, when to use them, and how they relate to Inspector-based debugging and SDK integration testing.

Fixes #1883

## Validation

- `git diff --check`
- `npx --yes markdownlint-cli@latest docs/validation-tools.md docs/roadmap.md --config .github/linters/.markdownlint.json`
- `/tmp/a2a-docs-venv/bin/mkdocs build --site-dir /tmp/a2a-site`

Note: `/tmp/a2a-docs-venv/bin/mkdocs build --strict --site-dir /tmp/a2a-site` still reports existing repository warnings for generated SDK/spec artifacts and existing specification anchors. The new validation tools page does not introduce strict-mode warnings.