### PR TITLE
ci: trigger docs build on changes to build inputs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,18 +7,24 @@ on:
     paths:
       - ".github/workflows/docs.yml"
       - "scripts/deploy_root_files.sh"
+      - "scripts/build_docs.sh"
       - "requirements-docs.txt"
       - "mkdocs.yml"
       - "docs/**"
+      - ".mkdocs/**"
+      - "specification/a2a.proto"
   pull_request:
     branches:
       - main
     paths:
       - ".github/workflows/docs.yml"
       - "scripts/deploy_root_files.sh"
+      - "scripts/build_docs.sh"
       - "requirements-docs.txt"
       - "mkdocs.yml"
       - "docs/**"
+      - ".mkdocs/**"
+      - "specification/a2a.proto"
   release:
     types:
       - published


### PR DESCRIPTION
## Summary

Fixes #1968.

The **Docs Build and Deploy** workflow (`.github/workflows/docs.yml`) only triggers when `docs/**`, `mkdocs.yml`, `requirements-docs.txt`, or the workflow file change. But the rendered site also depends on inputs that are **not** in the path filter:

- **`.mkdocs/**`** — the macros module (`.mkdocs/macros`) and theme overrides (`.mkdocs/overrides`), both referenced from `mkdocs.yml`
- **`specification/a2a.proto`** — the source the `proto_to_table` / `proto_service_to_table` macros parse to generate the API tables
- **`scripts/build_docs.sh`** — the build entrypoint the workflow actually runs

A change to any of these can break the build or alter every rendered page while CI stays green. Concrete example: the macros anchor fix in #1966 changes rendering logic for the whole spec, yet `build_and_deploy` never ran on it because `.mkdocs/**` wasn't watched.

## Change

Add `.mkdocs/**`, `specification/a2a.proto`, and `scripts/build_docs.sh` to both the `push` and `pull_request` path filters. No behavioral change to the build itself — it just runs in more of the cases where it should.

## Verification

- `docs.yml` parses as valid YAML.
- Both `paths:` blocks updated identically.
- Cross-checked the added paths against `mkdocs.yml` (`custom_dir: .mkdocs/overrides`, `module_name: .mkdocs/macros`) and `scripts/build_docs.sh` (reads `specification/a2a.proto`).
- This PR self-demonstrates the fix: editing `docs.yml` triggered `build_and_deploy`, which previously would not run for a `.mkdocs/`-only change.