### PR TITLE
ci: migrate from deprecated buf-setup-action to buf-action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -70,7 +70,10 @@ jobs:
         run: uv pip install --system --upgrade -r requirements-docs.txt
 
       - name: Setup Buf
-        uses: bufbuild/buf-setup-action@v1
+        uses: bufbuild/buf-action@v1
+        with:
+          setup_only: true
+          version: "1.71.0"
 
       - name: Setup Go
         uses: actions/setup-go@v6

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -39,7 +39,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Buf
-        uses: bufbuild/buf-setup-action@v1
+        uses: bufbuild/buf-action@v1
+        with:
+          setup_only: true
+          version: "1.71.0"
 
       - name: Download proto dependencies
         working-directory: specification


### PR DESCRIPTION
## Summary

Replace the deprecated `bufbuild/buf-setup-action` with the new consolidated `bufbuild/buf-action` in both CI workflows:

- `.github/workflows/linter.yaml`
- `.github/workflows/docs.yml`

### Changes

- Switch from `bufbuild/buf-setup-action@v1` to `bufbuild/buf-action@v1`
- Add `setup_only: true` to replicate the previous behavior (install buf CLI only, without running lint/breaking change/push operations)
- Pin buf CLI version to `1.71.0` to avoid unexpected breakages from future releases

Closes #1510