### PR TITLE
docs(spec): fix typo in specification.md metadata section

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -472,7 +472,7 @@ The `historyLength` parameter appears in multiple operations and controls how mu
 
 #### 3.2.5. Metadata
 
-A flexible key-value map for passing additional context or parameters with operations. Metadata keys and are strings and values can be any valid value that can be represented in JSON. [`Extensions`](#46-extensions) can be used to strongly type metadata values for specific use cases.
+A flexible key-value map for passing additional context or parameters with operations. Metadata keys are strings and values can be any valid value that can be represented in JSON. [`Extensions`](#46-extensions) can be used to strongly type metadata values for specific use cases.
 
 #### 3.2.6 Service Parameters
 


### PR DESCRIPTION
## Description

Fixes a small grammatical typo in the Metadata section of `docs/specification.md` (line 475). The sentence contained a stray `and`:

> Metadata keys **and** are strings and values can be any valid value that can be represented in JSON.

It now reads:

> Metadata keys are strings and values can be any valid value that can be represented in JSON.

## Related issue

Fixes #1950

(The earlier PR #1949 for this issue was closed without merging; this re-submits the one-word fix.)