### PR TITLE
docs(spec): fix Agent Card security requirement sample

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -2163,7 +2163,7 @@ Clients verifying Agent Card signatures **MUST**:
       }
     }
   },
-  "security": [{ "google": ["openid", "profile", "email"] }],
+  "securityRequirements": [{ "schemes": { "google": { "list": ["openid", "profile", "email"] } } }],
   "defaultInputModes": ["application/json", "text/plain"],
   "defaultOutputModes": ["application/json", "image/png"],
   "skills": [


### PR DESCRIPTION
# Description

The sample Agent Card still used the v0.3 `security` field even though the v1.0 specification makes `a2a.proto` authoritative and adopts strict ProtoJSON serialization. Readers copying the sample could therefore send a field that conforming v1.0 implementations do not recognize, making agent-level authentication requirements appear absent.

PR #1160 introduced the stale line while restructuring the specification around a transport-independent Protocol Buffers model. A later edit migrated the neighboring `securitySchemes` example, but this security-requirement line retained its v0.3 spelling and shape.

This change replaces that line with the complete v1.0 ProtoJSON representation:

```json
"securityRequirements": [{ "schemes": { "google": { "list": ["openid", "profile", "email"] } } }]
```

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/A2A/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title follow the Conventional Commits specification and repository rules (e.g., `docs(spec):` for `docs/specification.md`, `docs:` for other docs, and `feat:` / `fix:` reserved for `a2a.proto`). See [CONTRIBUTING.md](https://github.com/a2aproject/A2A/blob/main/CONTRIBUTING.md#conventional-commits) for details.
- [x] Ensure the tests and linter pass (Run `bash scripts/format.sh` from the repository root to format)
- [x] Appropriate docs were updated (if necessary)

Fixes #2044
