### PR TITLE
chore(codeowners): Add project maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,12 +5,14 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
 # Fallback owner for everything in the repository
-*                       @a2aproject/a2a-tsc @a2aproject/tech-writing @a2aproject/google-a2a-eng
+*                       @a2aproject/a2a-tsc @a2aproject/tech-writing @a2aproject/google-a2a-eng @a2aproject/a2a-project-maintainers
 
-# Core Specification and Governance (Exclusive TSC ownership, placed at bottom for final override)
-adrs/                   @a2aproject/a2a-tsc
-specification/          @a2aproject/a2a-tsc
-docs/specification.md   @a2aproject/a2a-tsc
+# Core Specification Maintainers and TSC ownership
+adrs/                   @a2aproject/a2a-tsc @a2aproject/a2a-project-maintainers
+specification/          @a2aproject/a2a-tsc @a2aproject/a2a-project-maintainers
+docs/specification.md   @a2aproject/a2a-tsc @a2aproject/a2a-project-maintainers
+
+# Governance/License and this file exclusive TSC ownership
 GOVERNANCE.md           @a2aproject/a2a-tsc
 .gitvote.yml            @a2aproject/a2a-tsc
 LICENSE                 @a2aproject/a2a-tsc


### PR DESCRIPTION
This adds the project maintainers team as owners of the specification to allow for non-TSC approvals for day to day management of the spec.

The TSC remain sole owner of Governance, License, and approving changes to the CODEOWNERs file.

closes: https://github.com/a2aproject/A2A/issues/2052