### PR TITLE
docs: add Agent Identity Protocol (AIP) to partners list

### DIFF
--- a/docs/partners.md
+++ b/docs/partners.md
@@ -11,6 +11,7 @@ collaborate effectively with each other and with users.
 - [Activeloop](https://www.activeloop.ai/)
 - [Adobe](https://www.adobe.com)
 - [AG2AI](https://ag2.ai)
+- [Agent Identity Protocol (AIP)](https://sunilprakash.com/aip/)
 - [AgentTrust](https://agenttrust.ai/)
 - [AI21 Labs](https://www.ai21.com/)
 - [AI71](https://ai71.ai/)


### PR DESCRIPTION
# Description

Adds Agent Identity Protocol (AIP) to the partners list. AIP is an open protocol for agent identity and delegation, with spec and implementations in Rust, Python, and TypeScript. The Python SDK ships an `aip_a2a` module that binds AIP identities and delegation chains to A2A agents.

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/A2A/blob/main/CONTRIBUTING.md).
- [x] PR title follows Conventional Commits (`docs:` for non-spec docs).
- [x] Ran markdownlint with the repo config on `docs/partners.md` (passes).
- [x] Single-line addition to the alphabetical partner list, no other docs affected.

Fixes #2054