### PR TITLE
docs: fix JSON schema download link

### DIFF
--- a/docs/definitions.md
+++ b/docs/definitions.md
@@ -22,7 +22,9 @@
 
     <h3>Download</h3>
 
-    You can download the schema file directly: [`a2a.json`](https://a2a-protocol.org/latest/spec/a2a.json)
+    You can download the version-specific schema file directly: [`a2a.json`](spec/a2a.json)
+
+    When viewing this source file on GitHub, use the [latest published schema](https://a2a-protocol.org/latest/spec/a2a.json) because the version-specific files are generated during documentation builds and are not committed to the repository.
 
     <h3>Definition</h3>
 

--- a/docs/definitions.md
+++ b/docs/definitions.md
@@ -22,7 +22,7 @@
 
     <h3>Download</h3>
 
-    You can download the schema file directly: [`a2a.json`](spec/a2a.json)
+    You can download the schema file directly: [`a2a.json`](https://a2a-protocol.org/latest/spec/a2a.json)
 
     <h3>Definition</h3>
 


### PR DESCRIPTION
# Description

`docs/definitions.md` links to a version-specific `spec/a2a.json` artifact that
is intentionally generated during documentation builds and therefore is not
available from the GitHub source view. Keep that relative link as the primary
download so versioned documentation continues to serve its matching schema,
and add an explicitly labeled link to the official published `latest` artifact
for readers viewing the Markdown source on GitHub.

## Validation

- `npx --yes markdownlint-cli docs/definitions.md --config .github/linters/.markdownlint.json`
- `.doc-venv/bin/mkdocs build`
- Confirmed the rendered `site/definitions/index.html` contains both the
  version-specific relative URL and the official `latest` fallback URL
- Confirmed `https://a2a-protocol.org/latest/spec/a2a.json` returns HTTP 200
- `git diff --check`

## Checklist

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/A2A/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title follow the Conventional Commits specification and repository rules (e.g., `docs(spec):` for `docs/specification.md`, `docs:` for other docs, and `feat:` / `fix:` reserved for `a2a.proto`). See [CONTRIBUTING.md](https://github.com/a2aproject/A2A/blob/main/CONTRIBUTING.md#conventional-commits) for details.
- [x] Ensure the tests and linter pass (Run `bash scripts/format.sh` from the repository root to format)
- [x] Appropriate docs were updated (if necessary)

## AI assistance

OpenAI Codex was used to inspect the existing schema-generation pipeline,
prepare this documentation change, address review feedback about versioned
documentation, and run the validation listed above.

Fixes #2057 🦕
