### PR TITLE
docs(spec): Recommend principle of least privilege for in-task authorization

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1960,6 +1960,7 @@ If using in-band credential exchange, we recommend adhering to the following sec
 
 - Credentials SHOULD be bound to the agent which originated the request, such that only this agent is able to use the credentials. This ensures that credentials propagating through a chain of A2A requests are only usable by the requesting agent.
 - Credentials containing sensitive information SHOULD be only readable by the agent which originated the request, such as by encrypting the credential.
+- Credentials SHOULD grant the minimal permissions required to perform the desired action.
 
 ## 8. Agent Discovery: The Agent Card
 


### PR DESCRIPTION
Add guidance for in-task authorization to scope credentials to the least privilege required for the requested action. SHOULD is used as there is no protocol defined way of specifying the representation of an action, other than via general guidance to use TaskStatus.message, nor a protocol requirement for using specific credential types that are capable of such tight scoping.