### PR TITLE
docs(spec): change SubscribeToTask HTTP method from POST to GET

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1166,7 +1166,7 @@ When an agent supports multiple protocols, all supported protocols **MUST**:
 | Get task                        | `GetTask`                          | `GetTask`                          | `GET /tasks/{id}`                                       |
 | List tasks                      | `ListTasks`                        | `ListTasks`                        | `GET /tasks`                                            |
 | Cancel task                     | `CancelTask`                       | `CancelTask`                       | `POST /tasks/{id}:cancel`                               |
-| Subscribe to task               | `SubscribeToTask`                  | `SubscribeToTask`                  | `POST /tasks/{id}:subscribe`                            |
+| Subscribe to task               | `SubscribeToTask`                  | `SubscribeToTask`                  | `GET /tasks/{id}:subscribe`                             |
 | Create push notification config | `CreateTaskPushNotificationConfig` | `CreateTaskPushNotificationConfig` | `POST /tasks/{id}/pushNotificationConfigs`              |
 | Get push notification config    | `GetTaskPushNotificationConfig`    | `GetTaskPushNotificationConfig`    | `GET /tasks/{id}/pushNotificationConfigs/{configId}`    |
 | List push notification configs  | `ListTaskPushNotificationConfigs`  | `ListTaskPushNotificationConfigs`  | `GET /tasks/{id}/pushNotificationConfigs`               |
@@ -2792,7 +2792,7 @@ A2A-Extensions: https://example.com/extensions/geolocation/v1,https://standards.
 - `GET /tasks/{id}` - Get task status
 - `GET /tasks` - List tasks (with query parameters)
 - `POST /tasks/{id}:cancel` - Cancel task
-- `POST /tasks/{id}:subscribe` - Subscribe to task updates (SSE response, returns error for terminal tasks)
+- `GET /tasks/{id}:subscribe` - Subscribe to task updates (SSE response, returns error for terminal tasks)
 
 #### 11.3.3. Push Notification Configuration
 


### PR DESCRIPTION
The proto definition (a2a.proto) uses GET with gRPC transcoding annotation for SubscribeToTask, but the specification document had POST in two places.

## Changes

- section 7.1 URL Reference table: `POST /tasks/{id}:subscribe` → `GET /tasks/{id}:subscribe`
- section 11.3.2 URL Reference list: same fix

## Evidence

Proto uses GET:
```proto
rpc SubscribeToTask(SubscribeToTaskRequest) returns (stream StreamResponse) {
  option (google.api.http) = {
    get: "/tasks/{id=*}:subscribe"
  };
}
```

GET is also the semantically correct method — SubscribeToTask is a read-only streaming operation (SSE), not a state-changing request.

Closes #2063