### PR TITLE
chore(security): move vulnerability intake to GitHub Security Advisories

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,6 @@
 # Security Policy
 
-To report a security issue, please use email <security@lists.a2aproject.org>.
+To report a security issue, please use GitHub Security Advisories:
+https://github.com/a2aproject/A2A/security/advisories
 
-We use a mailing list for our intake, and do coordination and disclosure here using GitHub Security Advisory to privately discuss and fix the issue.
+We use GitHub Security Advisories for private intake, coordination, and disclosure.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
 To report a security issue, please use GitHub Security Advisories:
-https://github.com/a2aproject/A2A/security/advisories
+[Security Advisories · a2aproject/A2A](https://github.com/a2aproject/A2A/security/advisories)
 
 We use GitHub Security Advisories for private intake, coordination, and disclosure.


### PR DESCRIPTION
## Summary
- Update security reporting guidance in SECURITY.md
- Replace mailing-list intake instructions with GitHub Security Advisories
- Clarify that private intake and coordination happen through GitHub Security Advisories

## Change
- Updated SECURITY.md to point reporters to:
  https://github.com/a2aproject/A2A/security/advisories

Fixes #2085
