### PR TITLE
docs(spec): clarify HTTP+JSON/REST response for google.protobuf.Empty

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -2858,6 +2858,27 @@ Content-Type: application/a2a+json
 
 **Referenced Objects:** [`Task`](#411-task)
 
+**Empty Responses:**
+
+Operations whose Protocol Buffer definition returns `google.protobuf.Empty` (currently only `DeleteTaskPushNotificationConfig`) **MUST** respond with `200 OK` and a JSON body of `{}`. This follows directly from the ProtoJSON mapping adopted for this binding (see [ADR-001](../adrs/adr-001-protojson-serialization.md)): the canonical JSON representation of `google.protobuf.Empty` is an empty JSON object, not an absent body. Implementations **MUST NOT** return `204 No Content` for these operations, since a `204` response carries no body and would be inconsistent with the `application/a2a+json` `Content-Type` used elsewhere in this binding.
+
+**Example Delete Push Notification Configuration:**
+
+```http
+DELETE /tasks/task-uuid/pushNotificationConfigs/config-uuid
+```
+
+**Response:**
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/a2a+json
+
+{}
+```
+
+**Referenced Objects:** [`DeleteTaskPushNotificationConfigRequest`](#10410-deletetaskpushnotificationconfig)
+
 ### 11.5. Query Parameter Naming for Request Parameters
 
 HTTP methods that do not support request bodies (GET, DELETE) **MUST** transmit operation request parameters as path parameters or query parameters. This section defines how to map Protocol Buffer field names to query parameter names.


### PR DESCRIPTION
## Summary
- `DeleteTaskPushNotificationConfig` is the only RPC returning `google.protobuf.Empty`, and Section 11 (HTTP+JSON/REST binding) never specified how that's represented on the wire.
- Per the ProtoJSON mapping already adopted in ADR-001, `Empty` serializes to an empty JSON object, so this adds an explicit rule: `200 OK` with a `{}` body, and a `MUST NOT` against `204 No Content` (which would be inconsistent with the binding's JSON `Content-Type`).
- Added a concrete example for the delete-config endpoint.

Fixes #1674

## Test plan
- Doc-only change; no build/test suite applies.
- Verified the new internal anchor link follows the same dots-stripped, lowercased pattern used elsewhere in the spec (e.g. `#321-sendmessagerequest`)