### PR TITLE
docs: broken links and link checker workflow fine tuning

### DIFF
--- a/.github/workflows/links.yaml
+++ b/.github/workflows/links.yaml
@@ -120,7 +120,7 @@ jobs:
         uses: lycheeverse/lychee-action@v2.0.2 # CVE-2024-48908: pin >=2.0.2
         with:
           lycheeVersion: "v0.22.0"
-          args: '--config lychee.toml --exclude-path "(^|/)404\\.html$" site'
+          args: '--config lychee.toml site'
           fail: true
           output: lychee/out.md
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/partners.md
+++ b/docs/partners.md
@@ -102,7 +102,7 @@ collaborate effectively with each other and with users.
 - [Lumika](https://lumika.ai)
 - [Lyzr.ai](https://lyzr.ai)
 - [Magyar Telekom](https://www.telekom.hu/)
-- [MasOrange](https://masorange.es/en/)
+- [MasOrange](https://masorange.es/)
 - [Microsoft](https://www.microsoft.com/en-us/microsoft-cloud/blog/2025/05/07/empowering-multi-agent-apps-with-the-open-agent2agent-a2a-protocol/)
 - [MindsDB](https://mindsdb.com/blog/mindsdb-now-supports-the-agent2agent-(a2a)-protocol)
 - [McKinsey](https://www.mckinsey.com)

--- a/lychee.toml
+++ b/lychee.toml
@@ -71,12 +71,20 @@ exclude = [
 exclude_path = [
     ".github/actions/spelling",
     "CHANGELOG.md",
+    # Source docs (PR / changed-file checks)
     "docs/partners.md",
     "docs/robots.txt",
     "docs/llms.txt",
     "docs/spec/a2a.json",
     "docs/spec-proto.md",
     "docs/sdk/python.md",
+    # Built site equivalents (scheduled site/ checks)
+    '(^|/)partners(/|$)',
+    '(^|/)robots\.txt$',
+    '(^|/)llms\.txt$',
+    '(^|/)spec/a2a\.json$',
+    '(^|/)spec-proto(/|$)',
+    '(^|/)sdk/python/index\.html$',
     '\.index(/|$)',
     '(^|/)404\.html$',
     'site/sdk/python/_build/',


### PR DESCRIPTION
Fixes #2104 and #2105

This PR fixes broken links and updates the Lychee workflow to exclude the build HTMLs of the excludes as well.