### PR TITLE
ci: harden docs workflow_dispatch version handling

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -138,8 +138,10 @@ jobs:
 
       - name: Manually deploy specific version from main
         if: github.event_name == 'workflow_dispatch'
+        env:
+          MIKE_VERSION: ${{ github.event.inputs.version }}
         run: |
-          mike deploy --push --update-aliases ${{ github.event.inputs.version }} latest
+          mike deploy --push --update-aliases "$MIKE_VERSION" latest
 
           echo "Setting 'latest' as the default version for the site..."
           mike set-default --push latest


### PR DESCRIPTION
Fixes #2110

# Description

CI hygiene for `.github/workflows/docs.yml` manual docs deploy path.

- Bind `github.event.inputs.version` under `env:` before `mike deploy` in `run:` (quoted `$MIKE_VERSION`).
- Mirrors the release path in the same file that already uses `env:` / `$MIKE_VERSION`.
- Defense-in-depth for privileged docs deploy — not framed as a vulnerability ticket.

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/A2A/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title follow the Conventional Commits specification and repository rules (e.g., `docs(spec):` for `docs/specification.md`, `docs:` for other docs, and `feat:` / `fix:` reserved for `a2a.proto`). See [CONTRIBUTING.md](https://github.com/a2aproject/A2A/blob/main/CONTRIBUTING.md#conventional-commits) for details.
- [ ] Ensure the tests and linter pass (Run `bash scripts/format.sh` from the repository root to format)
- [x] Appropriate docs were updated (if necessary)

## Test plan
- [ ] Workflow YAML review
- [ ] Optional `workflow_dispatch` with a stable version string when maintainers want
