### PR TITLE
docs: Update favicon to color version

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,7 +80,7 @@ theme:
     text: Google Sans
     code: Roboto Mono
   logo: assets/a2a_logo/icon/white/SVG/a2a_icon_white.svg
-  favicon: assets/a2a_logo/icon/white/SVG/a2a_icon_white.svg
+  favicon: assets/a2a_logo/icon/color/SVG/a2a_icon_color.svg
   icon:
     repo: fontawesome/brands/github
     view: material/pencil-box-multiple


### PR DESCRIPTION
The white favicon was not clearly visible on light-themed browser tabs. This change updates the site favicon to the color version for better visibility across different browser themes.


### With current PR

<img width="605" height="261" alt="Screenshot 2026-08-05 at 12 32 16 PM" src="https://github.com/user-attachments/assets/6c5cd588-74e2-4b71-a53e-bf1de9173f12" />


### A2A Site today

<img width="654" height="263" alt="Screenshot 2026-08-05 at 12 32 45 PM" src="https://github.com/user-attachments/assets/84048c5f-ed40-4e8e-9eba-e24b201986c6" />

