### PR TITLE
docs: add Dealer Handshake to partners list

### DIFF
--- a/docs/partners.md
+++ b/docs/partners.md
@@ -56,6 +56,7 @@ collaborate effectively with each other and with users.
 - [Datadog](https://www.datadoghq.com)
 - [DataRobot](https://www.datarobot.com)
 - [DataStax](https://www.datastax.com)
+- [Dealer Handshake](https://dealerhandshake.com/)
 - [Decagon.ai](https://decagon.ai)
 - [Deloitte](https://www.prnewswire.com/news-releases/deloitte-expands-alliances-with-google-cloud-and-servicenow-to-accelerate-agentic-ai-adoption-in-the-enterprise-302423941.html)
 - [Devnagri](https://devnagri.com)


### PR DESCRIPTION
Closes #2115

Adds **Dealer Handshake** to the partners list, in alphabetical position between DataStax and Decagon.ai.

Dealer Handshake connects dealership inventory and store data to AI assistants over A2A and routes consented shopper leads back into the dealer's CRM. It runs on the [Auto Agent Protocol](https://autoagentprotocol.org/) 1.0, a strict A2A v1.0 profile: the automotive message types ride on A2A's data layer, so an AAP dealer agent is a plain A2A agent to any client that has never heard of automotive.

**250+ rooftops are already live with published A2A agent cards**, queryable for real inventory with VINs and FTC-compliant pricing. We keep connecting dealers.

Building the profile took days rather than months because transport, discovery and the task lifecycle were already solved by A2A. We also publish A2A explainers for an automotive audience that had not heard of the protocol before this year.

### Related links

- https://dealerhandshake.com/
- https://autoagentprotocol.org/
- https://dealerhandshake.com/articles/a2a-the-quiet-protocol-that-lets-anything-talk-to-anything/
