### PR TITLE
feat: implement coherent task history — timeline + artifact ordering (ADR-002)

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -505,9 +505,9 @@ The `generation` field on [`Task`](#411-task) is a sequentially increasing integ
 
 - Appending a [`TimelineEntry`](#418-timelineentry): an agent status update (any [`TaskStatusUpdateEvent`](#421-taskstatusupdateevent), including a progress message that does not change `Task.status.state`), or a client message added to the task's `timeline`.
 - An Artifact addition or update (any change to `Task.artifacts`).
-- An [`Elicitation`](#419-elicitation) state change (any change to `Task.elicitations`).
+- An [`Elicitation`](#419-elicitation) creation or state change (any change to `Task.elicitations`).
 
-Mutations delivered to subscribers as streaming events — agent status updates ([`TaskStatusUpdateEvent`](#421-taskstatusupdateevent)) and artifact updates ([`TaskArtifactUpdateEvent`](#422-taskartifactupdateevent)) — **MUST** map 1:1 to exactly one emitted event whose `generation` value reflects the task's generation **after** the mutation. Other mutations (client-message timeline entries and elicitation state changes) also advance `generation` but are not necessarily delivered to every subscriber as a discrete event; clients reconcile these via [Get Task](#313-get-task) (see Event Ordering below).
+Mutations delivered to subscribers as streaming events — agent status updates ([`TaskStatusUpdateEvent`](#421-taskstatusupdateevent), which also carry any [`Elicitation`](#419-elicitation) delta) and artifact updates ([`TaskArtifactUpdateEvent`](#422-taskartifactupdateevent)) — **MUST** map 1:1 to exactly one emitted event whose `generation` value reflects the task's generation **after** the mutation. Client-message timeline entries also advance `generation` but are not necessarily delivered to every subscriber as a discrete event; clients reconcile these via [Get Task](#313-get-task) (see Event Ordering below).
 
 **Event Ordering and Missed-Event Detection:**
 
@@ -566,9 +566,23 @@ Because agent status entries are delivered by the existing [`TaskStatusUpdateEve
 
 <span id="329-elicitation-semantics"></span>
 
-An [`Elicitation`](#419-elicitation) is an explicit record of a request for client input. The `elicitations` field on [`Task`](#411-task) lets agents model input-required flows additively, without overloading the [`TaskState`](#413-taskstate) enum. Each elicitation has an [`ElicitationState`](#4110-elicitationstate) of `ELICITATION_STATE_WAITING`, `ELICITATION_STATE_BLOCKED`, or `ELICITATION_STATE_RESOLVED`, and MAY reference the agent [`Message`](#414-message) that requested the input.
+An [`Elicitation`](#419-elicitation) is an explicit record of a request for client input. The `elicitations` field on [`Task`](#411-task) lets agents model input-required flows additively, without overloading the [`TaskState`](#413-taskstate) enum. Each elicitation has an [`ElicitationState`](#4110-elicitationstate) of `ELICITATION_STATE_WAITING`, `ELICITATION_STATE_BLOCKED`, or `ELICITATION_STATE_RESOLVED`, and MAY reference the agent [`Message`](#414-message) that requested the input via `requestMessageId`.
 
-A task is considered to require input while any elicitation is in the `WAITING` or `BLOCKED` state. Servers MAY continue to set `Task.status.state` to `TASK_STATE_INPUT_REQUIRED` for backward compatibility; clients that understand `elicitations` **SHOULD** derive input-required status from the collection. An `Elicitation` state change is a generation-advancing mutation (see [Task Generation Semantics](#327-task-generation-semantics)).
+A task is considered to require input while any elicitation is in the `WAITING` or `BLOCKED` state. Servers MAY continue to set `Task.status.state` to `TASK_STATE_INPUT_REQUIRED` for backward compatibility; clients that understand `elicitations` **SHOULD** derive input-required status from the collection.
+
+**Creation and identity:**
+
+Elicitations are created and state-changed by the agent. An elicitation is normally created **together with the status update that requests the input**: the requesting agent message travels in that [`TaskStatusUpdateEvent`](#421-taskstatusupdateevent)'s `status.message`, and the elicitation's `requestMessageId` points back to it.
+
+Each elicitation is identified by `elicitationId`, which is unique within the task. Elicitations are **never removed**; they only transition between states (`WAITING` and `BLOCKED` are open states, `RESOLVED` is terminal). The collection is therefore monotonic and can be merged by `elicitationId`.
+
+**Delivery:**
+
+Elicitation creations and state changes are delivered to streaming clients via the `elicitations` field on [`TaskStatusUpdateEvent`](#421-taskstatusupdateevent) — a delta containing only the affected elicitations. No new streaming event type is introduced. A server MAY attach an elicitation delta to a status update it is already emitting, or emit a status update specifically to carry an elicitation change; such an elicitation-only update need not add a new [timeline](#328-task-timeline-semantics) entry. Clients **SHOULD** merge each delta into their view of `Task.elicitations` by `elicitationId`. The full current set is always available via [Get Task](#313-get-task).
+
+An `Elicitation` create or state change is a generation-advancing mutation and is delivered as part of the status update that carries it (see [Task Generation Semantics](#327-task-generation-semantics)).
+
+How a client indicates *which* elicitation a subsequent input satisfies is defined by the bidirectional interaction model and is out of scope for this version; agents resolve elicitations from interaction context.
 
 ### 3.3. Operation Semantics
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -503,11 +503,10 @@ As service parameter names MAY need to co-exist with other parameters defined by
 
 The `generation` field on [`Task`](#411-task) is a sequentially increasing integer maintained by the server. It is initialised to `1` when a task is created and **MUST** be incremented by exactly `1` by the server on every state-changing mutation:
 
-- Appending a [`TimelineEntry`](#418-timelineentry): an agent status update (any [`TaskStatusUpdateEvent`](#421-taskstatusupdateevent), including a progress message that does not change `Task.status.state`), or a client message added to the task's `timeline`.
+- Appending a [`TimelineEntry`](#418-timelineentry): an agent status update (any [`TaskStatusUpdateEvent`](#421-taskstatusupdateevent) — including a progress message that does not change `Task.status.state`, or one whose `status` carries an [`Elicitation`](#419-elicitation) delta), or a client message added to the task's `timeline`.
 - An Artifact addition or update (any change to `Task.artifacts`).
-- An [`Elicitation`](#419-elicitation) creation or state change (any change to `Task.elicitations`).
 
-Mutations delivered to subscribers as streaming events — agent status updates ([`TaskStatusUpdateEvent`](#421-taskstatusupdateevent), which also carry any [`Elicitation`](#419-elicitation) delta) and artifact updates ([`TaskArtifactUpdateEvent`](#422-taskartifactupdateevent)) — **MUST** map 1:1 to exactly one emitted event whose `generation` value reflects the task's generation **after** the mutation. Client-message timeline entries also advance `generation` but are not necessarily delivered to every subscriber as a discrete event; clients reconcile these via [Get Task](#313-get-task) (see Event Ordering below).
+Mutations delivered to subscribers as streaming events — agent status updates ([`TaskStatusUpdateEvent`](#421-taskstatusupdateevent), whose `status` also carries any [`Elicitation`](#419-elicitation) delta) and artifact updates ([`TaskArtifactUpdateEvent`](#422-taskartifactupdateevent)) — **MUST** map 1:1 to exactly one emitted event whose `generation` value reflects the task's generation **after** the mutation. Client-message timeline entries also advance `generation` but are not necessarily delivered to every subscriber as a discrete event; clients reconcile these via [Get Task](#313-get-task) (see Event Ordering below).
 
 **Event Ordering and Missed-Event Detection:**
 
@@ -566,21 +565,19 @@ Because agent status entries are delivered by the existing [`TaskStatusUpdateEve
 
 <span id="329-elicitation-semantics"></span>
 
-An [`Elicitation`](#419-elicitation) is an explicit record of a request for client input. The `elicitations` field on [`Task`](#411-task) lets agents model input-required flows additively, without overloading the [`TaskState`](#413-taskstate) enum. Each elicitation has an [`ElicitationState`](#4110-elicitationstate) of `ELICITATION_STATE_WAITING`, `ELICITATION_STATE_BLOCKED`, or `ELICITATION_STATE_RESOLVED`, and MAY reference the agent [`Message`](#414-message) that requested the input via `requestMessageId`.
+An [`Elicitation`](#419-elicitation) is an explicit record of a request for client input. It lets agents model input-required flows additively, without overloading the [`TaskState`](#413-taskstate) enum. Each elicitation has an [`ElicitationState`](#4110-elicitationstate) of `ELICITATION_STATE_WAITING`, `ELICITATION_STATE_BLOCKED`, or `ELICITATION_STATE_RESOLVED`.
 
-A task is considered to require input while any elicitation is in the `WAITING` or `BLOCKED` state. Servers MAY continue to set `Task.status.state` to `TASK_STATE_INPUT_REQUIRED` for backward compatibility; clients that understand `elicitations` **SHOULD** derive input-required status from the collection.
+The `elicitations` field on [`Task`](#411-task) is the authoritative, current set of the task's elicitations. A task is considered to require input while any elicitation is in the `WAITING` or `BLOCKED` state. Servers MAY continue to set `Task.status.state` to `TASK_STATE_INPUT_REQUIRED` for backward compatibility; clients that understand `elicitations` **SHOULD** derive input-required status from the collection.
 
-**Creation and identity:**
+**Creation, identity, and delivery:**
 
-Elicitations are created and state-changed by the agent. An elicitation is normally created **together with the status update that requests the input**: the requesting agent message travels in that [`TaskStatusUpdateEvent`](#421-taskstatusupdateevent)'s `status.message`, and the elicitation's `requestMessageId` points back to it.
+Elicitations are created and state-changed by the agent, normally **together with the status update that requests the input** — the requesting agent message travels in the same [`TaskStatus`](#412-taskstatus)'s `message`.
 
-Each elicitation is identified by `elicitationId`, which is unique within the task. Elicitations are **never removed**; they only transition between states (`WAITING` and `BLOCKED` are open states, `RESOLVED` is terminal). The collection is therefore monotonic and can be merged by `elicitationId`.
+Changes are carried as a **delta** on [`TaskStatus`](#412-taskstatus)`.elicitations`: only the elicitations created or changed at that status are included. Because the delta travels on the status, it is delivered to streaming clients by the [`TaskStatusUpdateEvent`](#421-taskstatusupdateevent) that carries the status, and it is captured in the [timeline](#328-task-timeline-semantics) — each status entry records what changed then, so walking the timeline reconstructs the elicitation history. No new streaming event type is introduced.
 
-**Delivery:**
+Each elicitation is identified by `elicitationId`, unique within the task. Elicitations are **never removed**; they only transition between states (`WAITING` and `BLOCKED` are open, `RESOLVED` is terminal). Clients **SHOULD** merge each status delta into `Task.elicitations` by `elicitationId`; the full current set is always available via [Get Task](#313-get-task).
 
-Elicitation creations and state changes are delivered to streaming clients via the `elicitations` field on [`TaskStatusUpdateEvent`](#421-taskstatusupdateevent) — a delta containing only the affected elicitations. No new streaming event type is introduced. A server MAY attach an elicitation delta to a status update it is already emitting, or emit a status update specifically to carry an elicitation change; such an elicitation-only update need not add a new [timeline](#328-task-timeline-semantics) entry. Clients **SHOULD** merge each delta into their view of `Task.elicitations` by `elicitationId`. The full current set is always available via [Get Task](#313-get-task).
-
-An `Elicitation` create or state change is a generation-advancing mutation and is delivered as part of the status update that carries it (see [Task Generation Semantics](#327-task-generation-semantics)).
+Because an elicitation change is part of the status that carries it, it is a status mutation and advances `generation` like any other status update (see [Task Generation Semantics](#327-task-generation-semantics)).
 
 How a client indicates *which* elicitation a subsequent input satisfies is defined by the bidirectional interaction model and is out of scope for this version; agents resolve elicitations from interaction context.
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -551,7 +551,7 @@ The [`timeline`](#418-timelineentry) field on [`Task`](#411-task) is the coheren
 - a client [`Message`](#414-message) — client input recorded in the task; or
 - an agent [`TaskStatus`](#412-taskstatus) — the agent's state and `message` at a point in the interaction, delivered to subscribers by the existing [`TaskStatusUpdateEvent`](#421-taskstatusupdateevent).
 
-Entries are ordered by their `generation` value, which establishes a total order independent of wall-clock time (see [Task Generation Semantics](#327-task-generation-semantics)). Servers **MUST** assign each appended entry the task's `generation` after the append.
+Entries are ordered by their `generation` value, which establishes a total order independent of wall-clock time (see [Task Generation Semantics](#327-task-generation-semantics)). Servers **MUST** assign each appended entry the task's `generation` after the append. These `generation` values are monotonic but **not contiguous**: other mutations (notably `Artifact` updates) also advance `generation`, so consumers **MUST NOT** assume timeline entries have consecutive `generation` values — gaps are expected, and artifacts are placed relative to entries via `startGeneration`/`endGeneration` (see *Interleaving artifacts with the timeline* below).
 
 The `timeline` supersedes the deprecated `history` field: it records the same messages (agent messages are carried inside `TaskStatus` entries; client messages appear as `Message` entries) plus ordering and state context. Servers **SHOULD** populate `timeline`; servers that also support 1.0 clients continue to populate `history` (see [History Length Semantics](#324-history-length-semantics)). The number of entries returned is controlled by `timelineLength`.
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -549,8 +549,8 @@ The `generation` field was introduced in version **1.1** of this specification. 
 
 The [`timeline`](#418-timelineentry) field on [`Task`](#411-task) is the coherent, generation-ordered record of the interaction on the wire. Each [`TimelineEntry`](#418-timelineentry) is a `oneof` carrying either:
 
-- an agent [`TaskStatus`](#412-taskstatus) — the agent's state and `message` at a point in the interaction, delivered to subscribers by the existing [`TaskStatusUpdateEvent`](#421-taskstatusupdateevent); or
-- a client [`Message`](#414-message) — client input recorded in the task.
+- a client [`Message`](#414-message) — client input recorded in the task; or
+- an agent [`TaskStatus`](#412-taskstatus) — the agent's state and `message` at a point in the interaction, delivered to subscribers by the existing [`TaskStatusUpdateEvent`](#421-taskstatusupdateevent).
 
 Entries are ordered by their `generation` value, which establishes a total order independent of wall-clock time (see [Task Generation Semantics](#327-task-generation-semantics)). Servers **MUST** assign each appended entry the task's `generation` after the append.
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -472,11 +472,13 @@ This wrapper allows streaming endpoints to return different types of updates thr
 
 #### 3.2.4. History Length Semantics
 
-The `historyLength` parameter appears in multiple operations and controls how much task history is returned in responses. This parameter follows consistent semantics across all operations:
+> **Deprecated:** `historyLength` (and the `history` field it controls) is deprecated as of version **1.1** in favour of `timelineLength` and the task [`timeline`](#328-task-timeline-semantics). Servers continue to honour `historyLength` and populate `history` throughout the 1.x line; both are removed in 2.0.
 
-- **Unset/undefined**: No limit imposed; server returns its default amount of history (implementation-defined, may be all history)
-- **0**: No history should be returned; the `history` field SHOULD be omitted
-- **> 0**: Return at most this many recent messages from the task's history
+The `historyLength` parameter controls how much task history is returned in responses; its replacement, `timelineLength`, controls how many [`timeline`](#418-timelineentry) entries are returned. Both parameters appear in multiple operations and follow the same, consistent semantics:
+
+- **Unset/undefined**: No limit imposed; the server returns its default amount (implementation-defined, may be all entries)
+- **0**: None should be returned; the corresponding field (`history` or `timeline`) SHOULD be omitted
+- **> 0**: Return at most this many most-recent entries
 
 #### 3.2.5. Metadata
 
@@ -501,14 +503,15 @@ As service parameter names MAY need to co-exist with other parameters defined by
 
 The `generation` field on [`Task`](#411-task) is a sequentially increasing integer maintained by the server. It is initialised to `1` when a task is created and **MUST** be incremented by exactly `1` by the server on every state-changing mutation:
 
-- A `TaskState` transition (any change to `Task.status.state`).
+- Appending a [`TimelineEntry`](#418-timelineentry): an agent status update (any [`TaskStatusUpdateEvent`](#421-taskstatusupdateevent), including a progress message that does not change `Task.status.state`), or a client message added to the task's `timeline`.
 - An Artifact addition or update (any change to `Task.artifacts`).
+- An [`Elicitation`](#419-elicitation) state change (any change to `Task.elicitations`).
 
-Each mutation **MUST** map 1:1 to exactly one emitted event. The `generation` value carried in [`TaskStatusUpdateEvent`](#421-taskstatusupdateevent) and [`TaskArtifactUpdateEvent`](#422-taskartifactupdateevent) **MUST** reflect the task's generation **after** the mutation that produced the event.
+Mutations delivered to subscribers as streaming events — agent status updates ([`TaskStatusUpdateEvent`](#421-taskstatusupdateevent)) and artifact updates ([`TaskArtifactUpdateEvent`](#422-taskartifactupdateevent)) — **MUST** map 1:1 to exactly one emitted event whose `generation` value reflects the task's generation **after** the mutation. Other mutations (client-message timeline entries and elicitation state changes) also advance `generation` but are not necessarily delivered to every subscriber as a discrete event; clients reconcile these via [Get Task](#313-get-task) (see Event Ordering below).
 
 **Event Ordering and Missed-Event Detection:**
 
-Because the server increments `generation` by exactly `1` per mutation, a client that tracks the last seen `generation` can detect missed events by observing gaps in the sequence. If a client receives an event with `generation = N+2` after previously seeing `generation = N`, it knows at least one event was not delivered and **SHOULD** re-fetch the full task state via [Get Task](#313-get-task) to reconcile.
+Because the server increments `generation` by exactly `1` per mutation, a client that tracks the last seen `generation` can detect that its view is behind by observing gaps in the sequence. If a client receives an event with `generation = N+2` after previously seeing `generation = N`, at least one intervening mutation has not been delivered to it — a missed event, or a mutation not delivered to that subscriber as a discrete event (such as a client-message timeline entry) — and it **SHOULD** re-fetch the full task state via [Get Task](#313-get-task) to reconcile.
 
 A correctly-implemented server **MUST NOT** emit two events for the same task with the same `generation` value. If a client observes any event carrying `generation = 0`, or observes two consecutive events for the same task carrying identical `generation` values, it **MUST** conclude that the server does not implement the `generation` field and **MUST NOT** use `generation` for ordering, long-polling, or precondition checks for the remainder of that interaction. The client **SHOULD** fall back to stream ordering or timestamps for sequencing.
 
@@ -539,6 +542,33 @@ The `ifGenerationMatch` field in [`SendMessageConfiguration`](#322-sendmessageco
 **Backwards Compatibility:**
 
 The `generation` field was introduced in version **1.1** of this specification. The field defaults to `0` in the Protocol Buffer encoding (proto3 default for `int64`). Clients that do not read or send `generation` continue to interoperate correctly with servers that support it. Servers that have not yet implemented `generation` will return `0` on all events and responses; since a correctly-implemented server always returns `generation ≥ 1`, clients will detect a `0` value as a signal that the server does not support the field and gracefully fall back.
+
+#### 3.2.8. Task Timeline Semantics
+
+<span id="328-task-timeline-semantics"></span>
+
+The [`timeline`](#418-timelineentry) field on [`Task`](#411-task) is the coherent, generation-ordered record of the interaction on the wire. Each [`TimelineEntry`](#418-timelineentry) is a `oneof` carrying either:
+
+- an agent [`TaskStatus`](#412-taskstatus) — the agent's state and `message` at a point in the interaction, delivered to subscribers by the existing [`TaskStatusUpdateEvent`](#421-taskstatusupdateevent); or
+- a client [`Message`](#414-message) — client input recorded in the task.
+
+Entries are ordered by their `generation` value, which establishes a total order independent of wall-clock time (see [Task Generation Semantics](#327-task-generation-semantics)). Servers **MUST** assign each appended entry the task's `generation` after the append.
+
+The `timeline` supersedes the deprecated `history` field: it records the same messages (agent messages are carried inside `TaskStatus` entries; client messages appear as `Message` entries) plus ordering and state context. Servers **SHOULD** populate `timeline`; servers that also support 1.0 clients continue to populate `history` (see [History Length Semantics](#324-history-length-semantics)). The number of entries returned is controlled by `timelineLength`.
+
+Because agent status entries are delivered by the existing [`TaskStatusUpdateEvent`](#421-taskstatusupdateevent), introducing the timeline requires **no new streaming event type**, and clients that do not understand the `timeline` field are unaffected on the wire. Live delivery of client-message timeline entries to other subscribers (for example, in bidirectional interactions) is out of scope for this version; such entries are observed via [Get Task](#313-get-task). The `oneof` in [`TimelineEntry`](#418-timelineentry) is an extension point: additional entry kinds MAY be added in future minor versions without a breaking change.
+
+**Interleaving artifacts with the timeline:**
+
+[`Artifact`](#417-artifact) objects are recorded separately from the timeline so that per-chunk streaming updates do not flood it. To place an artifact relative to timeline entries, an artifact carries `startGeneration` (the `generation` at which it first appeared) and `endGeneration` (the `generation` at which it completed; unset while it is still streaming). Consumers interleave artifacts with timeline entries by comparing these values against entry `generation`s.
+
+#### 3.2.9. Elicitation Semantics
+
+<span id="329-elicitation-semantics"></span>
+
+An [`Elicitation`](#419-elicitation) is an explicit record of a request for client input. The `elicitations` field on [`Task`](#411-task) lets agents model input-required flows additively, without overloading the [`TaskState`](#413-taskstate) enum. Each elicitation has an [`ElicitationState`](#4110-elicitationstate) of `ELICITATION_STATE_WAITING`, `ELICITATION_STATE_BLOCKED`, or `ELICITATION_STATE_RESOLVED`, and MAY reference the agent [`Message`](#414-message) that requested the input.
+
+A task is considered to require input while any elicitation is in the `WAITING` or `BLOCKED` state. Servers MAY continue to set `Task.status.state` to `TASK_STATE_INPUT_REQUIRED` for backward compatibility; clients that understand `elicitations` **SHOULD** derive input-required status from the collection. An `Elicitation` state change is a generation-advancing mutation (see [Task Generation Semantics](#327-task-generation-semantics)).
 
 ### 3.3. Operation Semantics
 
@@ -744,7 +774,7 @@ The A2A protocol provides three complementary mechanisms for clients to receive 
 
 All implementations MUST deliver events in the order they were generated. Events MUST NOT be reordered during transmission, regardless of protocol binding.
 
-Each [`TaskStatusUpdateEvent`](#421-taskstatusupdateevent) and [`TaskArtifactUpdateEvent`](#422-taskartifactupdateevent) carries the task's `generation` value after the mutation that produced it. Clients **SHOULD** use this value to verify that no events were missed (a gap in generation values indicates a missed event) and to establish a total ordering of events that is independent of wall-clock time. See [Task Generation Semantics](#327-task-generation-semantics) for details.
+Each [`TaskStatusUpdateEvent`](#421-taskstatusupdateevent) and [`TaskArtifactUpdateEvent`](#422-taskartifactupdateevent) carries the task's `generation` value after the mutation that produced it. Clients **SHOULD** use this value to detect when their view is behind (a gap in generation values) and to establish a total ordering of events that is independent of wall-clock time; on a gap a client **SHOULD** reconcile via [Get Task](#313-get-task). Agent status entries in the task [`timeline`](#418-timelineentry) are delivered by these existing events — no additional streaming event type is introduced for the timeline. See [Task Generation Semantics](#327-task-generation-semantics) and [Task Timeline Semantics](#328-task-timeline-semantics) for details.
 
 **Multiple Streams Per Task:**
 
@@ -821,6 +851,8 @@ Messages play several key roles:
 
 Messages SHOULD NOT be used to deliver task outputs. Results SHOULD BE returned using Artifacts associated with a Task. This separation allows for a clear distinction between communication (Messages) and data output (Artifacts).
 
+> **Deprecated:** the Task `history` field is deprecated as of version **1.1** in favour of the task [`timeline`](#328-task-timeline-semantics), which records the interaction (agent status entries and client messages) in generation order. Servers continue to populate `history` throughout the 1.x line; the behaviour below describes `history` during that period.
+
 The Task History field contains Messages exchanged during task execution. However, not all Messages are guaranteed to be persisted in the Task history; for example, transient informational messages may not be stored. Messages exchanged prior to task creation may not be stored in Task history. The agent is responsible to determine which Messages are persisted in the Task History.
 
 Clients using streaming to retrieve task updates MAY not receive all status update messages if the client is disconnected and then reconnects. Messages MUST NOT be considered a reliable delivery mechanism for critical information.
@@ -874,6 +906,28 @@ The A2A protocol defines a canonical data model using Protocol Buffers. All prot
 #### 4.1.7. Artifact
 
 {{ proto_to_table("Artifact") }}
+
+<a id="TimelineEntry"></a>
+
+#### 4.1.8. TimelineEntry
+
+{{ proto_to_table("TimelineEntry") }}
+
+See [Task Timeline Semantics](#328-task-timeline-semantics).
+
+<a id="Elicitation"></a>
+
+#### 4.1.9. Elicitation
+
+{{ proto_to_table("Elicitation") }}
+
+See [Elicitation Semantics](#329-elicitation-semantics).
+
+<a id="ElicitationState"></a>
+
+#### 4.1.10. ElicitationState
+
+{{ proto_enum_to_table("ElicitationState") }}
 
 ### 4.2. Streaming Events
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -567,7 +567,11 @@ Because agent status entries are delivered by the existing [`TaskStatusUpdateEve
 
 An [`Elicitation`](#419-elicitation) is an explicit record of a request for client input. It lets agents model input-required flows additively, without overloading the [`TaskState`](#413-taskstate) enum. Each elicitation has an [`ElicitationState`](#4110-elicitationstate) of `ELICITATION_STATE_WAITING`, `ELICITATION_STATE_BLOCKED`, or `ELICITATION_STATE_RESOLVED`.
 
-The `elicitations` field on [`Task`](#411-task) is the authoritative, current set of the task's elicitations. A task is considered to require input while any elicitation is in the `WAITING` or `BLOCKED` state. Servers MAY continue to set `Task.status.state` to `TASK_STATE_INPUT_REQUIRED` for backward compatibility; clients that understand `elicitations` **SHOULD** derive input-required status from the collection.
+The `elicitations` field on [`Task`](#411-task) is the authoritative, current set of the task's elicitations. The two open states differ in whether they stop the agent: an elicitation in `WAITING` is outstanding but the agent MAY continue other work, whereas an elicitation in `BLOCKED` prevents further progress until it is satisfied. Clients that understand `elicitations` **SHOULD** read the collection directly rather than inferring input-required status from `Task.status.state`.
+
+**Relationship to `TASK_STATE_INPUT_REQUIRED` (implementation guidance, not a protocol requirement):**
+
+The protocol does not mandate a mapping between elicitations and the [`TaskState`](#413-taskstate) enum, and this mapping is not conditioned on the negotiated protocol version. The expected default — typically provided by an SDK so agent authors need not manage the state themselves — is to set `Task.status.state` to `TASK_STATE_INPUT_REQUIRED` while at least one elicitation is `BLOCKED`, and to leave the state unchanged (for example `TASK_STATE_WORKING`) when the only open elicitations are `WAITING`. This keeps existing clients that read `Task.status.state` working unchanged, while clients that read `elicitations` additionally see non-blocking requests.
 
 **Creation, identity, and delivery:**
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -503,10 +503,10 @@ As service parameter names MAY need to co-exist with other parameters defined by
 
 The `generation` field on [`Task`](#411-task) is a sequentially increasing integer maintained by the server. It is initialised to `1` when a task is created and **MUST** be incremented by exactly `1` by the server on every state-changing mutation:
 
-- Appending a [`TimelineEntry`](#418-timelineentry): an agent status update (any [`TaskStatusUpdateEvent`](#421-taskstatusupdateevent) — including a progress message that does not change `Task.status.state`, or one whose `status` carries an [`Elicitation`](#419-elicitation) delta), or a client message added to the task's `timeline`.
+- Appending a [`TimelineEntry`](#418-timelineentry): an agent status update (any [`TaskStatusUpdateEvent`](#421-taskstatusupdateevent), including a progress message that does not change `Task.status.state`), or a client message added to the task's `timeline`.
 - An Artifact addition or update (any change to `Task.artifacts`).
 
-Mutations delivered to subscribers as streaming events — agent status updates ([`TaskStatusUpdateEvent`](#421-taskstatusupdateevent), whose `status` also carries any [`Elicitation`](#419-elicitation) delta) and artifact updates ([`TaskArtifactUpdateEvent`](#422-taskartifactupdateevent)) — **MUST** map 1:1 to exactly one emitted event whose `generation` value reflects the task's generation **after** the mutation. Client-message timeline entries also advance `generation` but are not necessarily delivered to every subscriber as a discrete event; clients reconcile these via [Get Task](#313-get-task) (see Event Ordering below).
+Mutations delivered to subscribers as streaming events — agent status updates ([`TaskStatusUpdateEvent`](#421-taskstatusupdateevent)) and artifact updates ([`TaskArtifactUpdateEvent`](#422-taskartifactupdateevent)) — **MUST** map 1:1 to exactly one emitted event whose `generation` value reflects the task's generation **after** the mutation. Client-message timeline entries also advance `generation` but are not necessarily delivered to every subscriber as a discrete event; clients reconcile these via [Get Task](#313-get-task) (see Event Ordering below).
 
 **Event Ordering and Missed-Event Detection:**
 
@@ -560,28 +560,6 @@ Because agent status entries are delivered by the existing [`TaskStatusUpdateEve
 **Interleaving artifacts with the timeline:**
 
 [`Artifact`](#417-artifact) objects are recorded separately from the timeline so that per-chunk streaming updates do not flood it. To place an artifact relative to timeline entries, an artifact carries `startGeneration` (the `generation` at which it first appeared) and `endGeneration` (the `generation` at which it completed; unset while it is still streaming). Consumers interleave artifacts with timeline entries by comparing these values against entry `generation`s.
-
-#### 3.2.9. Elicitation Semantics
-
-<span id="329-elicitation-semantics"></span>
-
-An [`Elicitation`](#419-elicitation) is an explicit record of a request for client input. It lets agents model input-required flows additively, without overloading the [`TaskState`](#413-taskstate) enum. Each elicitation has an [`ElicitationState`](#4110-elicitationstate) of `ELICITATION_STATE_WAITING`, `ELICITATION_STATE_BLOCKED`, or `ELICITATION_STATE_RESOLVED`.
-
-The `elicitations` field on [`Task`](#411-task) is the authoritative, current set of the task's elicitations. The two open states differ in whether they stop the agent: an elicitation in `WAITING` is outstanding but the agent MAY continue other work, whereas an elicitation in `BLOCKED` prevents further progress until it is satisfied. Clients that understand `elicitations` **SHOULD** read the collection directly rather than inferring input-required status from `Task.status.state`.
-
-**Relationship to `TASK_STATE_INPUT_REQUIRED` (implementation guidance, not a protocol requirement):**
-
-The protocol does not mandate a mapping between elicitations and the [`TaskState`](#413-taskstate) enum, and this mapping is not conditioned on the negotiated protocol version. The expected default — typically provided by an SDK so agent authors need not manage the state themselves — is to set `Task.status.state` to `TASK_STATE_INPUT_REQUIRED` while at least one elicitation is `BLOCKED`, and to leave the state unchanged (for example `TASK_STATE_WORKING`) when the only open elicitations are `WAITING`. This keeps existing clients that read `Task.status.state` working unchanged, while clients that read `elicitations` additionally see non-blocking requests.
-
-**Creation, identity, and delivery:**
-
-Elicitations are created and state-changed by the agent, normally **together with the status update that requests the input** — the requesting agent message travels in the same [`TaskStatus`](#412-taskstatus)'s `message`.
-
-Changes are carried as a **delta** on [`TaskStatus`](#412-taskstatus)`.elicitations`: only the elicitations created or changed at that status are included. Because the delta travels on the status, it is delivered to streaming clients by the [`TaskStatusUpdateEvent`](#421-taskstatusupdateevent) that carries the status, and it is captured in the [timeline](#328-task-timeline-semantics) — each status entry records what changed then, so walking the timeline reconstructs the elicitation history. No new streaming event type is introduced.
-
-Each elicitation is identified by `elicitationId`, unique within the task. Elicitations are **never removed**; they only transition between states (`WAITING` and `BLOCKED` are open, `RESOLVED` is terminal). Clients **SHOULD** merge each status delta into `Task.elicitations` by `elicitationId`; the full current set is always available via [Get Task](#313-get-task).
-
-Because an elicitation change is part of the status that carries it, it is a status mutation and advances `generation` like any other status update (see [Task Generation Semantics](#327-task-generation-semantics)).
 
 ### 3.3. Operation Semantics
 
@@ -927,20 +905,6 @@ The A2A protocol defines a canonical data model using Protocol Buffers. All prot
 {{ proto_to_table("TimelineEntry") }}
 
 See [Task Timeline Semantics](#328-task-timeline-semantics).
-
-<a id="Elicitation"></a>
-
-#### 4.1.9. Elicitation
-
-{{ proto_to_table("Elicitation") }}
-
-See [Elicitation Semantics](#329-elicitation-semantics).
-
-<a id="ElicitationState"></a>
-
-#### 4.1.10. ElicitationState
-
-{{ proto_enum_to_table("ElicitationState") }}
 
 ### 4.2. Streaming Events
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -555,7 +555,7 @@ Entries are ordered by their `generation` value, which establishes a total order
 
 The `timeline` supersedes the deprecated `history` field: it records the same messages (agent messages are carried inside `TaskStatus` entries; client messages appear as `Message` entries) plus ordering and state context. Servers **SHOULD** populate `timeline`; servers that also support 1.0 clients continue to populate `history` (see [History Length Semantics](#324-history-length-semantics)). The number of entries returned is controlled by `timelineLength`.
 
-Because agent status entries are delivered by the existing [`TaskStatusUpdateEvent`](#421-taskstatusupdateevent), introducing the timeline requires **no new streaming event type**, and clients that do not understand the `timeline` field are unaffected on the wire. Live delivery of client-message timeline entries to other subscribers (for example, in bidirectional interactions) is out of scope for this version; such entries are observed via [Get Task](#313-get-task). The `oneof` in [`TimelineEntry`](#418-timelineentry) is an extension point: additional entry kinds MAY be added in future minor versions without a breaking change.
+Because agent status entries are delivered by the existing [`TaskStatusUpdateEvent`](#421-taskstatusupdateevent), introducing the timeline requires **no new streaming event type**, and clients that do not understand the `timeline` field are unaffected on the wire. Live delivery of client-message timeline entries to other subscribers (for example, in bidirectional interactions) is out of scope for this version; such entries are observed via [Get Task](#313-get-task). The `oneof` in [`TimelineEntry`](#418-timelineentry) is an extension point: additional entry kinds MAY be added in future minor versions. Clients **MUST** fail open — a client that encounters a `TimelineEntry` whose `entry` is a kind it does not recognise **MUST** skip that entry rather than rejecting the timeline or aborting the stream. The entry's `generation` is still accounted for (it does not count as a gap), so ordering and missed-event detection continue to work across unknown entries.
 
 **Interleaving artifacts with the timeline:**
 
@@ -578,8 +578,6 @@ Changes are carried as a **delta** on [`TaskStatus`](#412-taskstatus)`.elicitati
 Each elicitation is identified by `elicitationId`, unique within the task. Elicitations are **never removed**; they only transition between states (`WAITING` and `BLOCKED` are open, `RESOLVED` is terminal). Clients **SHOULD** merge each status delta into `Task.elicitations` by `elicitationId`; the full current set is always available via [Get Task](#313-get-task).
 
 Because an elicitation change is part of the status that carries it, it is a status mutation and advances `generation` like any other status update (see [Task Generation Semantics](#327-task-generation-semantics)).
-
-How a client indicates *which* elicitation a subsequent input satisfies is defined by the bidirectional interaction model and is out of scope for this version; agents resolve elicitations from interaction context.
 
 ### 3.3. Operation Semantics
 

--- a/specification/a2a.proto
+++ b/specification/a2a.proto
@@ -354,12 +354,12 @@ message Artifact {
 message TimelineEntry {
   // The content of this timeline entry.
   oneof entry {
-    // An agent status recorded in the timeline: the state plus the agent's
-    // `message` at that point. Streamed via `TaskStatusUpdateEvent`.
-    TaskStatus status = 1;
     // A standalone message recorded in the timeline, used for client input
     // (`ROLE_USER`). Agent messages are carried by `status` entries.
-    Message message = 2;
+    Message message = 1;
+    // An agent status recorded in the timeline: the state plus the agent's
+    // `message` at that point. Streamed via `TaskStatusUpdateEvent`.
+    TaskStatus status = 2;
   }
   // The task's `generation` at the point this entry was appended. Entries are
   // ordered by this value, establishing a total order independent of wall-clock

--- a/specification/a2a.proto
+++ b/specification/a2a.proto
@@ -187,12 +187,22 @@ message Task {
   // protolint:enable REPEATED_FIELD_NAMES_PLURALIZED
   // A key/value object to store custom metadata about a task.
   google.protobuf.Struct metadata = 6;
-  // Sequentially increasing counter incremented by exactly 1 by the server
-  // on every state-changing mutation to this task (TaskState transition or
-  // Artifact addition/update), with each mutation mapping 1:1 to one event.
+  // Sequentially increasing counter incremented by exactly 1 by the server on
+  // every state-changing mutation to this task, with each mutation mapping 1:1
+  // to one event. Mutations include: a status update recorded as a
+  // `TimelineEntry` (any `TaskStatusUpdateEvent`, including a progress message
+  // that does not change `TaskState`); an `Artifact` addition or update; and an
+  // `Elicitation` state change.
   // Starts at 1 when the task is created.
   // May be used for event ordering, long-polling, and optimistic concurrency.
   int64 generation = 7;
+  // protolint:disable REPEATED_FIELD_NAMES_PLURALIZED
+  // Optional. The coherent, generation-ordered record of the task's status
+  // progression: the accumulated `TaskStatus` history. Each entry corresponds to
+  // a `TaskStatusUpdateEvent` already delivered on the wire, so no new event
+  // type is required to stream it. See ADR-002.
+  repeated TimelineEntry timeline = 8;
+  // protolint:enable REPEATED_FIELD_NAMES_PLURALIZED
 }
 
 // Defines the possible lifecycle states of a `Task`.
@@ -302,6 +312,31 @@ message Artifact {
   google.protobuf.Struct metadata = 5;
   // The URIs of extensions that are present or contributed to this Artifact.
   repeated string extensions = 6;
+}
+
+// `TimelineEntry` is a single, generation-ordered entry in a task's timeline.
+// The timeline is the coherent, replayable record of the interaction on the
+// wire: agent status progression (each `TaskStatus` carrying the agent's
+// `message` and state) interleaved with client messages, in the order they
+// occurred. Agent status entries are delivered on the wire by the existing
+// `TaskStatusUpdateEvent`, so the timeline needs no new event type. The `entry`
+// is a `oneof` so additional entry kinds can be added later without a breaking
+// change. See ADR-002.
+message TimelineEntry {
+  // The content of this timeline entry.
+  oneof entry {
+    // An agent status recorded in the timeline: the state plus the agent's
+    // `message` at that point. Streamed via `TaskStatusUpdateEvent`.
+    TaskStatus status = 1;
+    // A standalone message recorded in the timeline, used for client input
+    // (`ROLE_USER`). Agent messages are carried by `status` entries.
+    Message message = 2;
+  }
+  // The task's `generation` at the point this entry was appended. Entries are
+  // ordered by this value, establishing a total order independent of wall-clock
+  // time. Appending a `TimelineEntry` is itself a generation-incrementing
+  // mutation (see `Task.generation`).
+  int64 generation = 3;
 }
 
 // An event sent by the agent to notify the client of a change in a task's status.

--- a/specification/a2a.proto
+++ b/specification/a2a.proto
@@ -200,8 +200,8 @@ message Task {
   // every state-changing mutation to this task, with each mutation mapping 1:1
   // to one event. Mutations include: a status update recorded as a
   // `TimelineEntry` (any `TaskStatusUpdateEvent`, including a progress message
-  // that does not change `TaskState`); an `Artifact` addition or update; and an
-  // `Elicitation` state change.
+  // that does not change `TaskState`, or one whose `status` carries an
+  // `Elicitation` delta); and an `Artifact` addition or update.
   // Starts at 1 when the task is created.
   // May be used for event ordering, long-polling, and optimistic concurrency.
   int64 generation = 7;
@@ -359,8 +359,10 @@ message TimelineEntry {
   }
   // The task's `generation` at the point this entry was appended. Entries are
   // ordered by this value, establishing a total order independent of wall-clock
-  // time. Appending a `TimelineEntry` is itself a generation-incrementing
-  // mutation (see `Task.generation`).
+  // time. These values are monotonic but NOT contiguous: other mutations
+  // (notably `Artifact` updates) also advance `generation`, so gaps between
+  // entries are expected, and artifacts are placed relative to entries via their
+  // `start_generation`/`end_generation` (see `Task.generation`).
   int64 generation = 3;
 }
 

--- a/specification/a2a.proto
+++ b/specification/a2a.proto
@@ -332,20 +332,10 @@ message Artifact {
   // The URIs of extensions that are present or contributed to this Artifact.
   repeated string extensions = 6;
   // Optional. The task `generation` at which this artifact first appeared.
-  // Together with `end_generation`, this lets consumers interleave artifacts
-  // with the `timeline` without the timeline carrying per-chunk stream events.
-  // See ADR-002.
   int64 start_generation = 7;
-  // Optional. The task `generation` at which this artifact was completed (its
-  // last chunk). Unset while the artifact is still streaming; for a single-shot
-  // artifact it equals `start_generation`.
+  // Optional. The task `generation` at which this artifact was completed; unset
+  // while it is still streaming.
   int64 end_generation = 8;
-  // Optional. The originator of this artifact. Artifacts are agent outputs by
-  // default (`ROLE_AGENT`); a client-written (bidirectional) artifact is
-  // `ROLE_USER`. This preserves the input/output distinction as client-written
-  // artifacts are introduced. The mechanics of writing artifacts are specified
-  // separately (bidirectional streaming). See ADR-002.
-  Role role = 9;
 }
 
 // `TimelineEntry` is a single, generation-ordered entry in a task's timeline.

--- a/specification/a2a.proto
+++ b/specification/a2a.proto
@@ -147,11 +147,17 @@ message SendMessageConfiguration {
   // Configuration for the agent to send push notifications for task updates.
   // Task id should be empty when sending this configuration in a `SendMessage` request.
   TaskPushNotificationConfig task_push_notification_config = 2;
-  // The maximum number of most recent messages from the task's history to retrieve in
-  // the response. An unset value means the client does not impose any limit. A
-  // value of zero is a request to not include any messages. The server MUST NOT
-  // return more messages than the provided value, but MAY apply a lower limit.
-  optional int32 history_length = 3;
+  // Deprecated: use `timeline_length` instead. The maximum number of most recent
+  // messages from the task's history to retrieve in the response. An unset value
+  // means the client does not impose any limit. A value of zero is a request to
+  // not include any messages. The server MUST NOT return more messages than the
+  // provided value, but MAY apply a lower limit. Removed in 2.0. See ADR-002.
+  optional int32 history_length = 3 [deprecated = true];
+  // Optional. The maximum number of most recent `timeline` entries to retrieve
+  // in the response. An unset value means the client does not impose any limit;
+  // a value of zero requests no entries. The server MUST NOT return more entries
+  // than this value, but MAY apply a lower limit. See ADR-002.
+  optional int32 timeline_length = 6;
   // If `true`, the operation returns immediately after creating the task,
   // even if processing is still in progress.
   // If `false` (default), the operation MUST wait until the task reaches a
@@ -182,8 +188,11 @@ message Task {
   // A set of output artifacts for a `Task`.
   repeated Artifact artifacts = 4;
   // protolint:disable REPEATED_FIELD_NAMES_PLURALIZED
-  // The history of interactions from a `Task`.
-  repeated Message history = 5;
+  // Deprecated: read the task `timeline` instead, which records the interaction
+  // (agent status entries and client messages) in generation order. Servers
+  // continue to populate `history` throughout the v1.x line for backward
+  // compatibility; it is removed in 2.0. See ADR-002.
+  repeated Message history = 5 [deprecated = true];
   // protolint:enable REPEATED_FIELD_NAMES_PLURALIZED
   // A key/value object to store custom metadata about a task.
   google.protobuf.Struct metadata = 6;
@@ -772,11 +781,17 @@ message GetTaskRequest {
   string tenant = 1;
   // The resource ID of the task to retrieve.
   string id = 2 [(google.api.field_behavior) = REQUIRED];
-  // The maximum number of most recent messages from the task's history to retrieve. An
-  // unset value means the client does not impose any limit. A value of zero is
-  // a request to not include any messages. The server MUST NOT return more
-  // messages than the provided value, but MAY apply a lower limit.
-  optional int32 history_length = 3;
+  // Deprecated: use `timeline_length` instead. The maximum number of most recent
+  // messages from the task's history to retrieve. An unset value means the
+  // client does not impose any limit. A value of zero is a request to not
+  // include any messages. The server MUST NOT return more messages than the
+  // provided value, but MAY apply a lower limit. Removed in 2.0. See ADR-002.
+  optional int32 history_length = 3 [deprecated = true];
+  // Optional. The maximum number of most recent `timeline` entries to retrieve.
+  // An unset value means the client does not impose any limit; a value of zero
+  // requests no entries. The server MUST NOT return more entries than this
+  // value, but MAY apply a lower limit. See ADR-002.
+  optional int32 timeline_length = 5;
   // Optional. If set, the server SHOULD NOT return until the task's generation
   // is strictly greater than this value, enabling efficient long-polling.
   // The server MAY return earlier (e.g. on timeout) with the current task state.
@@ -803,8 +818,12 @@ message ListTasksRequest {
   // `ListTasksResponse.next_page_token`.
   // Provide this to retrieve the subsequent page.
   string page_token = 5;
-  // The maximum number of messages to include in each task's history.
-  optional int32 history_length = 6;
+  // Deprecated: use `timeline_length` instead. The maximum number of messages to
+  // include in each task's history. Removed in 2.0. See ADR-002.
+  optional int32 history_length = 6 [deprecated = true];
+  // Optional. The maximum number of `timeline` entries to include in each task.
+  // See ADR-002.
+  optional int32 timeline_length = 9;
   // Filter tasks which have a status updated after the provided timestamp in ISO 8601 format (e.g., "2023-10-27T10:00:00Z").
   // Only tasks with a status timestamp time greater than or equal to this value will be returned.
   google.protobuf.Timestamp status_timestamp_after = 7;

--- a/specification/a2a.proto
+++ b/specification/a2a.proto
@@ -252,6 +252,11 @@ message TaskStatus {
   // ISO 8601 Timestamp when the status was recorded.
   // Example: "2023-10-27T10:00:00Z"
   google.protobuf.Timestamp timestamp = 3;
+  // Optional. Elicitations created or changed at this status - a delta, not the
+  // full set. Because the delta travels on the status, it is delivered by
+  // `TaskStatusUpdateEvent` and captured in the `timeline`. Clients merge these
+  // into `Task.elicitations` by `elicitation_id`. See ADR-002.
+  repeated Elicitation elicitations = 4;
 }
 
 // `Part` represents a container for a section of communication content.
@@ -391,14 +396,8 @@ message Elicitation {
   string elicitation_id = 1 [(google.api.field_behavior) = REQUIRED];
   // The current state of this elicitation.
   ElicitationState state = 2 [(google.api.field_behavior) = REQUIRED];
-  // Optional. The `message_id` of the agent `Message` (carried in a timeline
-  // `TaskStatus` entry) that requests input.
-  string request_message_id = 3;
-  // Optional. The task's `generation` at which this elicitation last changed
-  // state.
-  int64 generation = 4;
   // Optional. Metadata associated with this elicitation.
-  google.protobuf.Struct metadata = 5;
+  google.protobuf.Struct metadata = 3;
 }
 
 // An event sent by the agent to notify the client of a change in a task's status.
@@ -415,12 +414,6 @@ message TaskStatusUpdateEvent {
   // to detect missed events (a gap in generation values) and to correlate
   // events with a specific task snapshot.
   int64 generation = 5;
-  // Optional. Elicitations created or changed by this update, identified by
-  // `elicitation_id`. This is a delta: only the affected elicitations are
-  // included. Clients merge them into `Task.elicitations` by `elicitation_id`
-  // (elicitations are never removed, only transitioned between states). See
-  // ADR-002.
-  repeated Elicitation elicitations = 6;
 }
 
 // A task delta where an artifact has been generated.

--- a/specification/a2a.proto
+++ b/specification/a2a.proto
@@ -193,6 +193,11 @@ message Task {
   // continue to populate `history` throughout the v1.x line for backward
   // compatibility; it is removed in 2.0. See ADR-002.
   repeated Message history = 5 [deprecated = true];
+  // Optional. The coherent, generation-ordered record of the interaction: agent
+  // status entries and client messages. Each status entry corresponds to a
+  // `TaskStatusUpdateEvent` already delivered on the wire, so no new event type
+  // is required to stream it. See ADR-002.
+  repeated TimelineEntry timeline = 8;
   // protolint:enable REPEATED_FIELD_NAMES_PLURALIZED
   // A key/value object to store custom metadata about a task.
   google.protobuf.Struct metadata = 6;
@@ -200,23 +205,10 @@ message Task {
   // every state-changing mutation to this task, with each mutation mapping 1:1
   // to one event. Mutations include: a status update recorded as a
   // `TimelineEntry` (any `TaskStatusUpdateEvent`, including a progress message
-  // that does not change `TaskState`, or one whose `status` carries an
-  // `Elicitation` delta); and an `Artifact` addition or update.
+  // that does not change `TaskState`); and an `Artifact` addition or update.
   // Starts at 1 when the task is created.
   // May be used for event ordering, long-polling, and optimistic concurrency.
   int64 generation = 7;
-  // protolint:disable REPEATED_FIELD_NAMES_PLURALIZED
-  // Optional. The coherent, generation-ordered record of the task's status
-  // progression: the accumulated `TaskStatus` history. Each entry corresponds to
-  // a `TaskStatusUpdateEvent` already delivered on the wire, so no new event
-  // type is required to stream it. See ADR-002.
-  repeated TimelineEntry timeline = 8;
-  // protolint:enable REPEATED_FIELD_NAMES_PLURALIZED
-  // Optional. The authoritative, current set of requests for client input,
-  // outstanding and resolved. `WAITING` requests do not stop the agent working;
-  // a `BLOCKED` one does. Lets consumers model input-required without changing
-  // the `TaskState` enum. See ADR-002.
-  repeated Elicitation elicitations = 9;
 }
 
 // Defines the possible lifecycle states of a `Task`.
@@ -252,11 +244,6 @@ message TaskStatus {
   // ISO 8601 Timestamp when the status was recorded.
   // Example: "2023-10-27T10:00:00Z"
   google.protobuf.Timestamp timestamp = 3;
-  // Optional. Elicitations created or changed at this status - a delta, not the
-  // full set. Because the delta travels on the status, it is delivered by
-  // `TaskStatusUpdateEvent` and captured in the `timeline`. Clients merge these
-  // into `Task.elicitations` by `elicitation_id`. See ADR-002.
-  repeated Elicitation elicitations = 4;
 }
 
 // `Part` represents a container for a section of communication content.
@@ -364,33 +351,6 @@ message TimelineEntry {
   // entries are expected, and artifacts are placed relative to entries via their
   // `start_generation`/`end_generation` (see `Task.generation`).
   int64 generation = 3;
-}
-
-// Defines the lifecycle states of an `Elicitation` (a request for client input).
-enum ElicitationState {
-  // The elicitation state is unspecified.
-  ELICITATION_STATE_UNSPECIFIED = 0;
-  // The agent is waiting for the client to satisfy this request; the task may
-  // continue other work in the meantime.
-  ELICITATION_STATE_WAITING = 1;
-  // The request is blocking task progress until it is satisfied. By convention
-  // (implementation guidance, not a protocol requirement) a task is reported as
-  // `TASK_STATE_INPUT_REQUIRED` while at least one elicitation is `BLOCKED`.
-  ELICITATION_STATE_BLOCKED = 2;
-  // The request has been satisfied or withdrawn.
-  ELICITATION_STATE_RESOLVED = 3;
-}
-
-// `Elicitation` is an explicit, additive record of a request for client input.
-// It lets consumers model input-required flows without overloading `TaskState`.
-// See ADR-002.
-message Elicitation {
-  // Unique identifier (e.g. UUID) for this elicitation within the task.
-  string elicitation_id = 1 [(google.api.field_behavior) = REQUIRED];
-  // The current state of this elicitation.
-  ElicitationState state = 2 [(google.api.field_behavior) = REQUIRED];
-  // Optional. Metadata associated with this elicitation.
-  google.protobuf.Struct metadata = 3;
 }
 
 // An event sent by the agent to notify the client of a change in a task's status.

--- a/specification/a2a.proto
+++ b/specification/a2a.proto
@@ -317,6 +317,21 @@ message Artifact {
   google.protobuf.Struct metadata = 5;
   // The URIs of extensions that are present or contributed to this Artifact.
   repeated string extensions = 6;
+  // Optional. The task `generation` at which this artifact first appeared.
+  // Together with `end_generation`, this lets consumers interleave artifacts
+  // with the `timeline` without the timeline carrying per-chunk stream events.
+  // See ADR-002.
+  int64 start_generation = 7;
+  // Optional. The task `generation` at which this artifact was completed (its
+  // last chunk). Unset while the artifact is still streaming; for a single-shot
+  // artifact it equals `start_generation`.
+  int64 end_generation = 8;
+  // Optional. The originator of this artifact. Artifacts are agent outputs by
+  // default (`ROLE_AGENT`); a client-written (bidirectional) artifact is
+  // `ROLE_USER`. This preserves the input/output distinction as client-written
+  // artifacts are introduced. The mechanics of writing artifacts are specified
+  // separately (bidirectional streaming). See ADR-002.
+  Role role = 9;
 }
 
 // `TimelineEntry` is a single, generation-ordered entry in a task's timeline.

--- a/specification/a2a.proto
+++ b/specification/a2a.proto
@@ -354,8 +354,9 @@ message Artifact {
 // `message` and state) interleaved with client messages, in the order they
 // occurred. Agent status entries are delivered on the wire by the existing
 // `TaskStatusUpdateEvent`, so the timeline needs no new event type. The `entry`
-// is a `oneof` so additional entry kinds can be added later without a breaking
-// change. See ADR-002.
+// is a `oneof` so additional entry kinds can be added later; clients MUST fail
+// open and skip an entry whose `entry` kind they do not recognise (its
+// `generation` is still accounted for). See ADR-002.
 message TimelineEntry {
   // The content of this timeline entry.
   oneof entry {

--- a/specification/a2a.proto
+++ b/specification/a2a.proto
@@ -415,6 +415,12 @@ message TaskStatusUpdateEvent {
   // to detect missed events (a gap in generation values) and to correlate
   // events with a specific task snapshot.
   int64 generation = 5;
+  // Optional. Elicitations created or changed by this update, identified by
+  // `elicitation_id`. This is a delta: only the affected elicitations are
+  // included. Clients merge them into `Task.elicitations` by `elicitation_id`
+  // (elicitations are never removed, only transitioned between states). See
+  // ADR-002.
+  repeated Elicitation elicitations = 6;
 }
 
 // A task delta where an artifact has been generated.

--- a/specification/a2a.proto
+++ b/specification/a2a.proto
@@ -212,9 +212,9 @@ message Task {
   // type is required to stream it. See ADR-002.
   repeated TimelineEntry timeline = 8;
   // protolint:enable REPEATED_FIELD_NAMES_PLURALIZED
-  // Optional. Outstanding and resolved requests for client input. The task is
-  // considered to require input while any elicitation is in the `WAITING` or
-  // `BLOCKED` state; this derives `INPUT_REQUIRED` additively without changing
+  // Optional. The authoritative, current set of requests for client input,
+  // outstanding and resolved. `WAITING` requests do not stop the agent working;
+  // a `BLOCKED` one does. Lets consumers model input-required without changing
   // the `TaskState` enum. See ADR-002.
   repeated Elicitation elicitations = 9;
 }
@@ -373,9 +373,9 @@ enum ElicitationState {
   // The agent is waiting for the client to satisfy this request; the task may
   // continue other work in the meantime.
   ELICITATION_STATE_WAITING = 1;
-  // The request is blocking task progress. While any elicitation is `WAITING`
-  // or `BLOCKED`, the task is considered to require input (`INPUT_REQUIRED`)
-  // without a change to the `TaskState` enum.
+  // The request is blocking task progress until it is satisfied. By convention
+  // (implementation guidance, not a protocol requirement) a task is reported as
+  // `TASK_STATE_INPUT_REQUIRED` while at least one elicitation is `BLOCKED`.
   ELICITATION_STATE_BLOCKED = 2;
   // The request has been satisfied or withdrawn.
   ELICITATION_STATE_RESOLVED = 3;

--- a/specification/a2a.proto
+++ b/specification/a2a.proto
@@ -203,6 +203,11 @@ message Task {
   // type is required to stream it. See ADR-002.
   repeated TimelineEntry timeline = 8;
   // protolint:enable REPEATED_FIELD_NAMES_PLURALIZED
+  // Optional. Outstanding and resolved requests for client input. The task is
+  // considered to require input while any elicitation is in the `WAITING` or
+  // `BLOCKED` state; this derives `INPUT_REQUIRED` additively without changing
+  // the `TaskState` enum. See ADR-002.
+  repeated Elicitation elicitations = 9;
 }
 
 // Defines the possible lifecycle states of a `Task`.
@@ -337,6 +342,39 @@ message TimelineEntry {
   // time. Appending a `TimelineEntry` is itself a generation-incrementing
   // mutation (see `Task.generation`).
   int64 generation = 3;
+}
+
+// Defines the lifecycle states of an `Elicitation` (a request for client input).
+enum ElicitationState {
+  // The elicitation state is unspecified.
+  ELICITATION_STATE_UNSPECIFIED = 0;
+  // The agent is waiting for the client to satisfy this request; the task may
+  // continue other work in the meantime.
+  ELICITATION_STATE_WAITING = 1;
+  // The request is blocking task progress. While any elicitation is `WAITING`
+  // or `BLOCKED`, the task is considered to require input (`INPUT_REQUIRED`)
+  // without a change to the `TaskState` enum.
+  ELICITATION_STATE_BLOCKED = 2;
+  // The request has been satisfied or withdrawn.
+  ELICITATION_STATE_RESOLVED = 3;
+}
+
+// `Elicitation` is an explicit, additive record of a request for client input.
+// It lets consumers model input-required flows without overloading `TaskState`.
+// See ADR-002.
+message Elicitation {
+  // Unique identifier (e.g. UUID) for this elicitation within the task.
+  string elicitation_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // The current state of this elicitation.
+  ElicitationState state = 2 [(google.api.field_behavior) = REQUIRED];
+  // Optional. The `message_id` of the agent `Message` (carried in a timeline
+  // `TaskStatus` entry) that requests input.
+  string request_message_id = 3;
+  // Optional. The task's `generation` at which this elicitation last changed
+  // state.
+  int64 generation = 4;
+  // Optional. Metadata associated with this elicitation.
+  google.protobuf.Struct metadata = 5;
 }
 
 // An event sent by the agent to notify the client of a change in a task's status.


### PR DESCRIPTION
Fixes #1991

## Summary

Implements the coherent task history model from **ADR-002** (#2084, tracking #1991) in the proto (`specification/a2a.proto`) and the normative spec prose (`docs/specification.md`), on top of the merged `generation` field (#1810). **Additive and backward compatible**, and deliberately **introduces no new wire event**: the timeline reuses the existing `TaskStatusUpdateEvent` for delivery.

> Elicitations were **split out** of this PR into #2149 following review feedback, so this change is now scoped to the timeline alone.

## Design (why it's non-breaking)

The `timeline` is a restructuring of the **Task snapshot**, not a new event on the wire. `TimelineEntry` is a `oneof`:

- `Message message` — client messages recorded in the task.
- `TaskStatus status` — agent status progression (state + the agent's `message`), delivered by the **existing** `TaskStatusUpdateEvent`.

This matters because a new member of the stream event union is **not** safely ignorable today: a2a-go, a2a-java and a2a-rs all hard-error on an unrecognised event (java's `StreamingEventKind` is a `sealed interface`), a2a-python raises on strict `ParseDict`, and a2a-js / python-gRPC silently drop it. Reusing an existing event avoids that entirely.

`TaskStatus.message` is **retained** (not deprecated): the "latest status message" pollution problem is solved by the timeline retaining the *full ordered* sequence of statuses rather than just the head.

## What's included

1. **`TimelineEntry`** `{ oneof { Message message; TaskStatus status } int64 generation }` + `repeated TimelineEntry timeline` on `Task`. Widens `generation` so appending a timeline entry increments it (previously only `TaskState` transitions and artifact add/update counted, so a progress message that doesn't change state wouldn't advance it).
2. **Artifact interleaving** — `start_generation` / `end_generation` on `Artifact`, so artifacts are placed relative to timeline entries without per-chunk events flooding the timeline.
3. **`history` deprecation** — the timeline supersedes it, so `Task.history` and the three `history_length` params are soft-deprecated and `timeline_length` added. Deprecated fields stay populated/honored through v1.x, removed in 2.0.
4. **Spec prose** — Task Timeline Semantics (§3.2.8), artifact interleaving, the deprecation, the widened generation mutation set, and a `TimelineEntry` object section.

## Notes for reviewers

- **Fail-open is normative**: clients **MUST** skip a `TimelineEntry` whose `oneof` kind they don't recognise (its `generation` still counts), so future entry kinds are additive.
- **Timeline generations are monotonic but not contiguous** — artifact updates also consume generation numbers, so gaps between entries are expected.
- Live delivery of *client-message* timeline entries to third-party subscribers is deferred to the bidirectional work (a new method, where both parties are 1.1 by construction).
- `Artifact.role` was dropped from this PR and deferred to bidi, per review.

Related: #2084 (ADR-002), #2149 (elicitations), #1810, #1794



