### PR TITLE
docs: add FAF to partners list

### DIFF
--- a/docs/partners.md
+++ b/docs/partners.md
@@ -67,7 +67,7 @@ collaborate effectively with each other and with users.
 - [Ema.co](https://ema.co)
 - [EPAM](https://www.epam.com)
 - [Eviden (Atos Group)](https://atos.net/)
-- [FAF](https://faf.one/blog/fafa-speaks-a2a)
+- [FAF](https://faf.one/)
 - [fractal.ai](https://fractal.ai/new)
 - [GenAI Nebula9.ai Solutions Pvt Ltd](http://nebula9.ai)
 - [Glean](https://www.glean.com)

--- a/docs/partners.md
+++ b/docs/partners.md
@@ -67,6 +67,7 @@ collaborate effectively with each other and with users.
 - [Ema.co](https://ema.co)
 - [EPAM](https://www.epam.com)
 - [Eviden (Atos Group)](https://atos.net/)
+- [FAF](https://www.iana.org/assignments/media-types/application/vnd.fafa+yaml)
 - [fractal.ai](https://fractal.ai/new)
 - [GenAI Nebula9.ai Solutions Pvt Ltd](http://nebula9.ai)
 - [Glean](https://www.glean.com)

--- a/docs/partners.md
+++ b/docs/partners.md
@@ -67,7 +67,7 @@ collaborate effectively with each other and with users.
 - [Ema.co](https://ema.co)
 - [EPAM](https://www.epam.com)
 - [Eviden (Atos Group)](https://atos.net/)
-- [FAF](https://www.iana.org/assignments/media-types/application/vnd.fafa+yaml)
+- [FAF](https://faf.one/blog/fafa-speaks-a2a)
 - [fractal.ai](https://fractal.ai/new)
 - [GenAI Nebula9.ai Solutions Pvt Ltd](http://nebula9.ai)
 - [Glean](https://www.glean.com)


### PR DESCRIPTION
Closes #2137

Adds **FAF** to the partners list.

FAFA — the Voice of FAF — is a live A2A peer (protocol 1.0, JSON-RPC `message/send`). Other agents discover it from the Agent Card and call the door. Complementary: we do not replace the card.

### Related links

- https://faf.one/blog/fafa-speaks-a2a
- https://faf.one/.well-known/agent-card.json
- https://faf.one/agent