### PR TITLE
chore(governance): update ServiceNow representative

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -106,12 +106,14 @@ Qvandrcy
 RFCs
 RPCs
 RUF
+Rakha
 SFDC
 SLAs
 SLF
 SSLv
 Siwach
 Solax
+Sugandh
 TJS
 TMDB
 Tful
@@ -282,12 +284,12 @@ llm
 llms
 lng
 logtostderr
+maeste
 marvin
 mcp
 mcr
 mesop
 mikefarah
-maeste
 mindsdb
 mintlify
 mistervvp
@@ -326,7 +328,6 @@ pypa
 pypackages
 pytype
 pyupgrade
-Rakha
 qwq
 rcm
 regen
@@ -337,7 +338,6 @@ rst
 rvelicheti
 sandijean
 scm
-Sugandh
 siwachabhi
 sllm
 sourced

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -287,6 +287,7 @@ mcp
 mcr
 mesop
 mikefarah
+maeste
 mindsdb
 mintlify
 mistervvp
@@ -325,6 +326,7 @@ pypa
 pypackages
 pytype
 pyupgrade
+Rakha
 qwq
 rcm
 regen
@@ -335,6 +337,7 @@ rst
 rvelicheti
 sandijean
 scm
+Sugandh
 siwachabhi
 sllm
 sourced

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -9,7 +9,7 @@ The Agent2Agent project is governed by the Technical Steering Committee. The Com
 | **Cisco** | Luca Muscariello | Distinguished Engineer | [@muscariello](https://github.com/muscariello) |
 | **Amazon Web Services** | Abhimanyu Siwach | Senior Software Engineer | [@siwachabhi](https://github.com/siwachabhi) |
 | **Salesforce** | Stephen Petschulat | Principal Architect | [@spetschulatSFDC](https://github.com/spetschulatSFDC) |
-| **ServiceNow** | Sean Hughes | Director of Open Science | [@hughesthe1st](https://github.com/hughesthe1st) |
+| **ServiceNow** | Sugandh Rakha | Head of Product (MCP & A2A) | [sugandhrakha (Sugandh Rakha)](https://github.com/sugandhrakha) |
 | **SAP** | Sivakumar N. | Vice President | [@SivaNSAP](https://github.com/SivaNSAP) |
 | **IBM** | Stefano Maestri | Principal Software Engineer | [@maeste](https://github.com/maeste) |
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -9,7 +9,7 @@ The Agent2Agent project is governed by the Technical Steering Committee. The Com
 | **Cisco** | Luca Muscariello | Distinguished Engineer | [@muscariello](https://github.com/muscariello) |
 | **Amazon Web Services** | Abhimanyu Siwach | Senior Software Engineer | [@siwachabhi](https://github.com/siwachabhi) |
 | **Salesforce** | Stephen Petschulat | Principal Architect | [@spetschulatSFDC](https://github.com/spetschulatSFDC) |
-| **ServiceNow** | Sugandh Rakha | Head of Product (MCP & A2A) | [sugandhrakha (Sugandh Rakha)](https://github.com/sugandhrakha) |
+| **ServiceNow** | Sugandh Rakha | Head of Product (MCP & A2A) | [@sugandhrakha](https://github.com/sugandhrakha) |
 | **SAP** | Sivakumar N. | Vice President | [@SivaNSAP](https://github.com/SivaNSAP) |
 | **IBM** | Stefano Maestri | Principal Software Engineer | [@maeste](https://github.com/maeste) |
 


### PR DESCRIPTION
Replace Sean Hughes with Sugandh Rakha as the ServiceNow representative in GOVERNANCE.md.