### PR TITLE
chore: adding discord links

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/become_a_repo_maintainer.md
+++ b/.github/PULL_REQUEST_TEMPLATE/become_a_repo_maintainer.md
@@ -25,4 +25,4 @@ Once accepted you'll be able to commit to this repo!
 - [ ] I have at least one merged Pull Request
 - [ ] I have reviewed the [contribution guidelines](https://github.com/a2aproject/A2A/blob/main/CONTRIBUTING.md)
 - [ ] I have enabled [2FA on my GitHub account](https://github.com/settings/security)
-- [ ] I have joined the A2A discord
+- [ ] I have joined the [A2A Discord](https://discord.gg/a2aprotocol)

--- a/.github/PULL_REQUEST_TEMPLATE/become_a_repo_maintainer.md
+++ b/.github/PULL_REQUEST_TEMPLATE/become_a_repo_maintainer.md
@@ -12,15 +12,15 @@ TSC voting majority will be required to approve maintainers.
 
 Once accepted you'll be able to commit to this repo!
 
-### GitHub user id
+## GitHub user id
 
 - List your GitHub user id
 
-### Company affiliation
+## Company affiliation
 
 - List your company name, or indicate Individual if you're not affiliated with a company
 
-### Requirements
+## Requirements
 
 - [ ] I have at least one merged Pull Request
 - [ ] I have reviewed the [contribution guidelines](https://github.com/a2aproject/A2A/blob/main/CONTRIBUTING.md)

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -164,6 +164,7 @@ airbnb
 aldridge
 alloydb
 amannn
+amye
 aparse
 aproject
 aprotocol

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,3 +109,9 @@ You may follow these steps to contribute:
 8. **Resolve any feedback.** Work with reviewers to address any comments or requested changes.
 
 Be patient! It may take some time for your pull request to be reviewed and merged.
+
+## Community
+
+- **Discord:** Join the [A2A Discord server](https://discord.gg/a2aprotocol) for chat and questions.
+- **GitHub Discussions:** Join the [A2A GitHub Discussions](https://github.com/a2aproject/A2A/discussions) for longer-form conversations.
+- **Issues:** Report bugs or suggest improvements via [GitHub Issues](https://github.com/a2aproject/A2A/issues).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -77,7 +77,7 @@ Our [working doc for TSC Meeting Agendas](https://docs.google.com/document/d/1Dx
 
 ## Project Communications
 
-The A2A project utilizes Discord for chat conversations about the project. All are welcome and encouraged to join the [A2A Discord](http://discord.gg/a2aprotocol). Discussion is encouraged however we do remind the community that chat is ephemeral, and not all members of the project are active in chat at the same time.
+The A2A project utilizes Discord for chat conversations about the project. All are welcome and encouraged to join the [A2A Discord](https://discord.gg/a2aprotocol). Discussion is encouraged however we do remind the community that chat is ephemeral, and not all members of the project are active in chat at the same time.
 
 Therefore, any discussions about feature proposals, significant changes to the project architecture or governance, etc. should be held in GitHub with adequate notice and time for comment. Look for specifics on that timing coming soon as the TSC ramps up. Just keep in mind - our goal is that GitHub is the source of truth for significant project decisions.
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ As AI agents become more prevalent, their ability to interoperate is crucial for
 
 We welcome community contributions to enhance and evolve the A2A protocol!
 
-- **Questions & Discussions:** Join our [GitHub Discussions](https://github.com/a2aproject/A2A/discussions).
+- **Questions & Discussions:** Join our [GitHub Discussions](https://github.com/a2aproject/A2A/discussions) or the [A2A Discord server](https://discord.gg/a2aprotocol).
 - **Issues & Feedback:** Report issues or suggest improvements via [GitHub Issues](https://github.com/a2aproject/A2A/issues).
 - **Contribution Guide:** See our [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute.
 - **Private Feedback:** Use this [Google Form](https://goo.gle/a2a-feedback).

--- a/docs/community.md
+++ b/docs/community.md
@@ -2,6 +2,10 @@
 
 Welcome to the official community hub for the **Agent2Agent (A2A) protocol**! A2A is an open, standardized protocol that enables seamless interoperability and collaboration between AI agents across all frameworks and vendors.
 
+## Connect on Discord
+
+Join the [A2A Discord server](https://discord.gg/a2aprotocol) to chat with contributors, ask questions, and stay connected with the community.
+
 ## Recent News & Blog Posts
 
 Stay up-to-date with the latest announcements, tutorials, and insights from the A2A team and our community.
@@ -109,7 +113,7 @@ Building an A2A agent in a language not covered by the [official SDKs](./sdk/ind
 
 The excitement surrounding Google's A2A protocol clearly indicates a strong belief in its potential to revolutionize multi-agent AI systems. By providing a standardized way for AI agents to communicate and collaborate, A2A is poised to unlock new levels of automation and innovation. As enterprises increasingly adopt AI agents, A2A represents a crucial step towards realizing the full power of interconnected AI ecosystems.
 
-**Join the growing community building the future of AI interoperability with A2A!**
+**Join the growing community building the future of AI interoperability with A2A!** Connect on [Discord](https://discord.gg/a2aprotocol).
 
 ---
 
@@ -117,6 +121,7 @@ The excitement surrounding Google's A2A protocol clearly indicates a strong beli
 
 Looking for the live community meeting schedule or past recordings?
 
+- [A2A Discord server](https://discord.gg/a2aprotocol)
 - [A2A meetings on the Linux Foundation platform](https://zoom-lfx.platform.linuxfoundation.org/meetings/agent2agent)
 - [TSC meeting agenda working doc](https://docs.google.com/document/d/1Dx6qYfCjSChHKRMwLJcvtDjq6igYTAKFW9Vg1IMPCUk/view)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -157,6 +157,8 @@ A2A is a focused protocol. To set expectations, here is what it explicitly does 
 
 A2A was originally developed by Google and donated to the Linux Foundation. It is maintained by a Technical Steering Committee with representatives from AWS, Cisco, Google, IBM Research, Microsoft, Salesforce, SAP, and ServiceNow, and supported by a broad community of [partners](./partners.md).
 
+Join the community on [Discord](https://discord.gg/a2aprotocol) to connect with contributors, ask questions, and discuss the protocol.
+
 For details on how the project is run, see [`GOVERNANCE.md`](https://github.com/a2aproject/A2A/blob/main/GOVERNANCE.md) and [`MAINTAINERS.md`](https://github.com/a2aproject/A2A/blob/main/MAINTAINERS.md).
 
 ## License

--- a/docs/tutorials/python/8-next-steps.md
+++ b/docs/tutorials/python/8-next-steps.md
@@ -33,6 +33,7 @@ Here are some ideas and resources to continue your A2A journey:
     - Explore implementing push notifications if your agent's tasks are very long-lived.
     - Consider more complex input and output modalities (e.g., handling file uploads/downloads via file Parts, or structured data via data Parts).
 - **Contribute to the A2A Community:**
+    - Join the [A2A Discord server](https://discord.gg/a2aprotocol).
     - Join the discussions on the [A2A GitHub Discussions page](https://github.com/a2aproject/A2A/discussions).
     - Report issues or suggest improvements via [GitHub Issues](https://github.com/a2aproject/A2A/issues).
     - Consider contributing code, examples, or documentation. See the [CONTRIBUTING.md](https://github.com/a2aproject/A2A/blob/main/CONTRIBUTING.md) guide.

--- a/lychee.toml
+++ b/lychee.toml
@@ -55,6 +55,9 @@ exclude = [
     'https://codimite\.ai/',
     'github\.com/open-telemetry/opentelemetry-',
 
+    # Third-party README translation mirrors (currently unavailable)
+    'openaitx\.github\.io',
+
     # GitHub pages that redirect or require auth in CI
     'https://github\.com/settings/developers',
     'https://github\.com/login/device',


### PR DESCRIPTION
fixes #2145 

This PR adds the Discord invite link to the docs main page, community page, and readme among other places.