### PR TITLE
docs: clarify Hybrid Agents section in Life of a Task

### DIFF
--- a/docs/topics/life-of-a-task.md
+++ b/docs/topics/life-of-a-task.md
@@ -60,14 +60,16 @@ Conceptually, agents operate at different levels of complexity:
     approach avoids deciding between `Task` versus `Message`, but creates completed task objects
     for even simple interactions.
 - **Hybrid Agents**: Generate both `Message` and `Task` objects. These agents
-    use messages to negotiate agent capability and the scope of work for a task,
-    then send a `Task` object to track execution and manage states like
-    `input-required` or error handling. Once a task is created, the agent will
-    only return `Task` objects in response to messages sent, and once a task is
-    complete, no more messages can be sent. A hybrid agent uses messages to
-    negotiate the scope of a task, and then generates a task to track its
-    execution.
-    For more information about hybrid agents, see [A2A protocol: Demystifying Tasks vs Messages](https://discuss.google.dev/t/a2a-protocol-demystifying-tasks-vs-messages/255879).
+    use messages to negotiate agent capability and the scope of work, then send a
+    `Task` object to track execution and manage states like `input-required` or
+    error handling. In other words, `Message` objects carry the lightweight
+    back-and-forth that establishes what should be done, and a `Task` is created
+    once there is committed work to execute and observe. As with task-generating
+    agents, once a task is created the agent returns only `Task` objects in
+    response to subsequent messages, and once a task is complete no more messages
+    can be sent to it.
+
+    For a deeper discussion of when to use messages versus tasks, see [A2A protocol: Demystifying Tasks vs Messages](https://discuss.google.dev/t/a2a-protocol-demystifying-tasks-vs-messages/255879).
 
 ## Task Refinements
 


### PR DESCRIPTION
## Description

The **Hybrid Agents** description on the [Life of a Task](https://a2a-protocol.org/latest/topics/life-of-a-task/#agent-response-message-or-task) page read as incomplete compared to the *Message-only* and *Task-generating* descriptions:

- It repeated its scope-negotiation sentence ("uses messages to negotiate the scope of a task, then generates a task to track its execution") twice.
- It relied on an external forum link to convey a core concept, rather than explaining it inline.

This change:

- Tightens the paragraph and removes the duplicated sentence.
- Adds a self-contained explanation of the message-vs-task split (messages carry the lightweight negotiation; a `Task` is created once there is committed work to execute and observe).
- Demotes the external thread to an optional "deeper discussion" link rather than the primary explanation, keeping the page a self-contained source of truth for the three agent archetypes.

No normative/spec semantics change — documentation only (`docs/topics/life-of-a-task.md`).

## Validation

- 4-space list indentation preserved (markdownlint `MD007`).

## Checklist

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/A2A/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title follow the Conventional Commits specification (`docs:` for non-`specification.md` docs).
- [x] Ensure the tests and linter pass.
- [x] Appropriate docs were updated.

Fixes #1736