### PR TITLE
docs(spec): correct v1 migration field names

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -3516,7 +3516,7 @@ For **Clients** upgrading from pre-0.3.x:
 
 1. Update parsers to expect wrapper objects with member names as discriminators
 2. When constructing requests, use the new wrapper format
-3. Implement version detection based on the agent's `protocolVersions` in the `AgentCard`
+3. Implement version detection based on the agent's `supportedInterfaces[].protocolVersion`
 4. Consider maintaining backward compatibility by detecting and handling both formats during a transition period
 
 For **Servers** upgrading from pre-0.3.x:
@@ -3524,7 +3524,7 @@ For **Servers** upgrading from pre-0.3.x:
 1. Update serialization logic to emit wrapper objects
 2. **Breaking:** The `kind` field is no longer part of the protocol and should not be emitted
 3. Update deserialization to expect wrapper objects with member names
-4. Ensure the `AgentCard` declares the correct `protocolVersions` (e.g., ["1.0"] or later)
+4. Ensure each `supportedInterfaces[].protocolVersion` is set correctly (e.g., "1.0" or later)
 
 **Rationale:**
 

--- a/docs/whats-new-v1.md
+++ b/docs/whats-new-v1.md
@@ -699,12 +699,12 @@ const response = await listTasks({ page: 1, perPage: 50 });
 **After (v1.0):**
 
 ```typescript
-let cursor = undefined;
+let pageToken = undefined;
 do {
-  const response = await listTasks({ cursor, limit: 50 });
+  const response = await listTasks({ pageToken, pageSize: 50 });
   // process response.tasks
-  cursor = response.nextCursor;
-} while (cursor);
+  pageToken = response.nextPageToken;
+} while (pageToken);
 ```
 
 #### 5. Enum Value Changes (HIGH IMPACT)

--- a/tests/test_proto_json_names.py
+++ b/tests/test_proto_json_names.py
@@ -1,0 +1,98 @@
+import re
+import unittest
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PROTO_PATH = REPO_ROOT / 'specification' / 'a2a.proto'
+WHATS_NEW_PATH = REPO_ROOT / 'docs' / 'whats-new-v1.md'
+SPEC_PATH = REPO_ROOT / 'docs' / 'specification.md'
+
+_FIELD_RE = re.compile(
+    r'^\s*(?:optional|repeated|required)?\s*'
+    r'(?:map\s*<[^>]+>|[\w.]+)\s+'
+    r'([A-Za-z_]\w*)\s*=\s*\d+',
+    re.MULTILINE,
+)
+
+
+def proto_json_name(field_name: str) -> str:
+    parts = field_name.split('_')
+    return parts[0] + ''.join(part.capitalize() for part in parts[1:])
+
+
+def message_fields(proto_text: str, message_name: str) -> set[str]:
+    marker = f'message {message_name}'
+    start = proto_text.find(marker)
+    if start < 0:
+        raise AssertionError(f'message {message_name} not found in proto')
+    brace = proto_text.find('{', start)
+    if brace < 0:
+        raise AssertionError(f'message {message_name} has no body')
+    depth = 0
+    for index, char in enumerate(proto_text[brace:], start=brace):
+        if char == '{':
+            depth += 1
+        elif char == '}':
+            depth -= 1
+            if depth == 0:
+                body = proto_text[brace + 1 : index]
+                body = re.sub(r'//.*?$', '', body, flags=re.MULTILINE)
+                return set(_FIELD_RE.findall(body))
+    raise AssertionError(f'message {message_name} is unclosed')
+
+
+def after_v1_pagination_fence(markdown: str) -> str:
+    section = re.search(
+        r'#### 4\. Pagination.*?(?=#### |\Z)',
+        markdown,
+        re.DOTALL,
+    )
+    if not section:
+        raise AssertionError('pagination section not found')
+    fence = re.search(
+        r'\*\*After \(v1\.0\):\*\*\s*```(?:typescript|ts|js)?\n(.*?)```',
+        section.group(0),
+        re.DOTALL,
+    )
+    if not fence:
+        raise AssertionError('After (v1.0) pagination fence not found')
+    return fence.group(1)
+
+
+class ProtoJsonNameTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.proto = PROTO_PATH.read_text(encoding='utf-8')
+        cls.whats_new = WHATS_NEW_PATH.read_text(encoding='utf-8')
+        cls.spec = SPEC_PATH.read_text(encoding='utf-8')
+        cls.request_fields = message_fields(cls.proto, 'ListTasksRequest')
+        cls.response_fields = message_fields(cls.proto, 'ListTasksResponse')
+
+    def test_list_tasks_proto_defines_pagination_fields(self):
+        self.assertIn('page_size', self.request_fields)
+        self.assertIn('page_token', self.request_fields)
+        self.assertIn('page_size', self.response_fields)
+        self.assertIn('next_page_token', self.response_fields)
+        self.assertNotIn('cursor', self.request_fields)
+        self.assertNotIn('limit', self.request_fields)
+        self.assertNotIn('next_cursor', self.response_fields)
+
+    def test_v1_after_pagination_uses_protojson_names(self):
+        fence = after_v1_pagination_fence(self.whats_new)
+        self.assertIn(proto_json_name('page_token'), fence)
+        self.assertIn(proto_json_name('page_size'), fence)
+        self.assertIn(proto_json_name('next_page_token'), fence)
+        self.assertNotIn('nextCursor', fence)
+        self.assertNotIn('limit:', fence)
+        self.assertNotIn('"cursor"', fence)
+        self.assertNotIn('cursor:', fence)
+
+    def test_specification_does_not_read_agentcard_protocol_versions(self):
+        self.assertNotIn('protocolVersions', self.spec)
+        self.assertIn('supportedInterfaces[].protocolVersion', self.spec)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #2162.

The v1 migration guide used pagination names that are not defined by `ListTasksRequest` or `ListTasksResponse`. Clients copying the example sent `cursor` and `limit`, then read `nextCursor`, so conforming ProtoJSON implementations could stop after the first page.

This updates `docs/whats-new-v1.md` to use `pageToken`, `pageSize`, and `nextPageToken`. It also corrects `docs/specification.md` to read protocol versions from `AgentCard.supportedInterfaces[].protocolVersion` rather than the nonexistent `protocolVersions` field.

Focused tests derive the pagination field names from `specification/a2a.proto` and guard both migration examples against these invalid names.

## Testing

`python3 -m unittest tests.test_proto_json_names -v`

`git diff --check`
