### PR TITLE
docs(spec): fix pagination field names in migration docs

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -3516,7 +3516,7 @@ For **Clients** upgrading from pre-0.3.x:
 
 1. Update parsers to expect wrapper objects with member names as discriminators
 2. When constructing requests, use the new wrapper format
-3. Implement version detection based on the agent's `protocolVersions` in the `AgentCard`
+3. Implement version detection based on `protocolVersion` in the agent's `supportedInterfaces` entries
 4. Consider maintaining backward compatibility by detecting and handling both formats during a transition period
 
 For **Servers** upgrading from pre-0.3.x:
@@ -3524,7 +3524,7 @@ For **Servers** upgrading from pre-0.3.x:
 1. Update serialization logic to emit wrapper objects
 2. **Breaking:** The `kind` field is no longer part of the protocol and should not be emitted
 3. Update deserialization to expect wrapper objects with member names
-4. Ensure the `AgentCard` declares the correct `protocolVersions` (e.g., ["1.0"] or later)
+4. Ensure each `AgentInterface` in the `AgentCard` declares the correct `protocolVersion` (e.g., "1.0" or later)
 
 **Rationale:**
 

--- a/docs/whats-new-v1.md
+++ b/docs/whats-new-v1.md
@@ -699,12 +699,12 @@ const response = await listTasks({ page: 1, perPage: 50 });
 **After (v1.0):**
 
 ```typescript
-let cursor = undefined;
+let pageToken = undefined;
 do {
-  const response = await listTasks({ cursor, limit: 50 });
+  const response = await listTasks({ pageToken, pageSize: 50 });
   // process response.tasks
-  cursor = response.nextCursor;
-} while (cursor);
+  pageToken = response.nextPageToken;
+} while (pageToken);
 ```
 
 #### 5. Enum Value Changes (HIGH IMPACT)


### PR DESCRIPTION
## Summary

Fixes #2162

- Fixed `cursor`/`limit`/`nextCursor` → `pageToken`/`pageSize`/`nextPageToken` in the pagination migration example in `whats-new-v1.md`
- Fixed `AgentCard.protocolVersions` → `AgentInterface.protocolVersion` in upgrade instructions in `specification.md`

## Test plan

- [x] Code example in whats-new-v1.md uses correct v1.0 field names (`pageToken`, `pageSize`, `nextPageToken`)
- [x] Upgrade guidance references correct type path (`supportedInterfaces` entries, not `AgentCard` directly)