### PR TITLE
docs(spec): fix HTTP method for SubscribeToTask REST binding

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1166,7 +1166,7 @@ When an agent supports multiple protocols, all supported protocols **MUST**:
 | Get task                        | `GetTask`                          | `GetTask`                          | `GET /tasks/{id}`                                       |
 | List tasks                      | `ListTasks`                        | `ListTasks`                        | `GET /tasks`                                            |
 | Cancel task                     | `CancelTask`                       | `CancelTask`                       | `POST /tasks/{id}:cancel`                               |
-| Subscribe to task               | `SubscribeToTask`                  | `SubscribeToTask`                  | `POST /tasks/{id}:subscribe`                            |
+| Subscribe to task               | `SubscribeToTask`                  | `SubscribeToTask`                  | `GET /tasks/{id}:subscribe`                             |
 | Create push notification config | `CreateTaskPushNotificationConfig` | `CreateTaskPushNotificationConfig` | `POST /tasks/{id}/pushNotificationConfigs`              |
 | Get push notification config    | `GetTaskPushNotificationConfig`    | `GetTaskPushNotificationConfig`    | `GET /tasks/{id}/pushNotificationConfigs/{configId}`    |
 | List push notification configs  | `ListTaskPushNotificationConfigs`  | `ListTaskPushNotificationConfigs`  | `GET /tasks/{id}/pushNotificationConfigs`               |


### PR DESCRIPTION
## Summary
- The Method Mapping Reference table (§5.3) listed `SubscribeToTask`'s REST endpoint as `POST /tasks/{id}:subscribe`, but the proto definition (a2a.proto) binds it to `GET`.
- `SubscribeToTask` is a read/subscribe operation (non-mutating), consistent with `GetTask` and `ListTasks`, both of which are `GET` in the same table — unlike `CancelTask`, which mutates state and is correctly `POST`.
- This aligns the doc table with the proto source of truth.

Fixes #1574

## Test plan
- [x] Confirmed via `grep` that `a2a.proto` rpc `SubscribeToTask` uses `option (google.api.http) = { get: ... }`
- [x] No other spec.md sections state the REST method for this RPC (only the §5.3 table)