### PR TITLE
docs(spec): document TaskArtifactUpdateEvent lifecycle semantics

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -825,6 +825,13 @@ The A2A protocol defines a canonical data model using Protocol Buffers. All prot
 
 {{ proto_to_table("TaskArtifactUpdateEvent") }}
 
+**Artifact lifecycle semantics:**
+
+- An artifact is identified by its `artifactId` and is scoped to the task/context in which it was emitted.
+- `append = false` **MUST** create a new artifact, or entirely replace an existing artifact with the same `artifactId`.
+- `append = true` **MUST** append the parts of this event's `artifact` to the previously sent artifact with the same `artifactId`. If no artifact with that `artifactId` exists yet, the event **MUST** create a new artifact (i.e. `append = true` on a first event behaves like `append = false`).
+- `lastChunk = true` marks the artifact as **sealed**. Once an artifact is sealed, the agent **MUST NOT** send any further `TaskArtifactUpdateEvent` for that `artifactId`. Servers and clients **MAY** treat a subsequent update to a sealed artifact as an agent implementation bug and reject or drop the event rather than silently applying it.
+
 ### 4.3. Push Notification Objects
 
 <a id="PushNotificationConfig"></a>


### PR DESCRIPTION
## Summary
`TaskArtifactUpdateEvent`'s `append`/`lastChunk` fields had no normative
prose in the spec (§4.2.2 was just the auto-generated proto table) —
only field comments in a2a.proto. This left artifact replace/append/seal
behavior unspecified, per #1231.

Adds prose codifying the semantics that converged in the #1231
discussion (darrelmiller, Tehsmash, yarolegovich):

- `append = false` creates or fully replaces an artifact
- `append = true` appends to an existing artifact with the same
  `artifactId`, or creates one if it doesn't exist yet
- `lastChunk = true` seals the artifact; any further update to that
  `artifactId` is an agent-implementation bug, not valid protocol usage

## Scope
Doc-only. Does not touch a2a.proto or attempt the separate "allow
empty-parts artifacts for metadata-only deltas" question raised in the
same thread — that needs a proto-level decision and is out of scope here.
No overlap with the open ADR-002 PRs (#2129, #2149), which address task
timeline/generation ordering, not append/seal semantics.

Fixes #1231