### PR TITLE
docs(spec): fix ListTasks pagination and AgentCard protocolVersion field names

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -3516,7 +3516,7 @@ For **Clients** upgrading from pre-0.3.x:
 
 1. Update parsers to expect wrapper objects with member names as discriminators
 2. When constructing requests, use the new wrapper format
-3. Implement version detection based on the agent's `protocolVersions` in the `AgentCard`
+3. Implement version detection based on the agent's `protocolVersion` in each `supportedInterfaces` entry of the `AgentCard`
 4. Consider maintaining backward compatibility by detecting and handling both formats during a transition period
 
 For **Servers** upgrading from pre-0.3.x:
@@ -3524,7 +3524,7 @@ For **Servers** upgrading from pre-0.3.x:
 1. Update serialization logic to emit wrapper objects
 2. **Breaking:** The `kind` field is no longer part of the protocol and should not be emitted
 3. Update deserialization to expect wrapper objects with member names
-4. Ensure the `AgentCard` declares the correct `protocolVersions` (e.g., ["1.0"] or later)
+4. Ensure each `supportedInterfaces` entry of the `AgentCard` declares the correct `protocolVersion` (e.g., "1.0" or later)
 
 **Rationale:**
 

--- a/docs/whats-new-v1.md
+++ b/docs/whats-new-v1.md
@@ -699,12 +699,12 @@ const response = await listTasks({ page: 1, perPage: 50 });
 **After (v1.0):**
 
 ```typescript
-let cursor = undefined;
+let pageToken;
 do {
-  const response = await listTasks({ cursor, limit: 50 });
+  const response = await listTasks({ pageToken, pageSize: 50 });
   // process response.tasks
-  cursor = response.nextCursor;
-} while (cursor);
+  pageToken = response.nextPageToken;
+} while (pageToken);
 ```
 
 #### 5. Enum Value Changes (HIGH IMPACT)


### PR DESCRIPTION
Fixes #2162

The v1 migration guide documents ListTasks pagination with `cursor`/`limit`/`nextCursor`, but those names are not on `ListTasksRequest`/`ListTasksResponse` in `specification/a2a.proto`. ProtoJSON clients should send `pageToken`/`pageSize` and read `nextPageToken` (`page_token`/`page_size`/\`next_page_token\` in the proto).

Also corrects two references to `AgentCard.protocolVersions`, which is not a field on the card. Versions live on `supportedInterfaces[].protocolVersion` (`AgentInterface.protocol_version` in the proto).

Changes:
- `docs/whats-new-v1.md`: pagination example now uses `pageToken`/`pageSize`/`nextPageToken`
- `docs/specification.md`: migration notes reference `protocolVersion` per `supportedInterfaces` entry

All three field names verified against `specification/a2a.proto` (`ListTasksRequest` lines 676-693, `ListTasksResponse` lines 704-712, `AgentInterface.protocol_version` line 355).