### PR TITLE
chore: add rust and repo maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,6 +4,14 @@ This document lists the maintainers of various repositories within the project.
 
 ## Repository Maintainers
 
+### a2a
+
+- role:maintain
+  - @Tehsmash
+  - @herczyn
+  - @vinoo999
+  - @mikeas1
+
 ### a2a-dotnet
 
 - role:maintain
@@ -73,6 +81,14 @@ This document lists the maintainers of various repositories within the project.
   - @kthota-g
   - @ToddSegal
   - @zeroasterisk
+
+### a2a-rs
+
+- role:maintain
+  - @muscariello
+  - @Tehsmash
+  - @msardara
+  - @micpapal
 
 ### a2a-samples
 


### PR DESCRIPTION
Adds the Rust SDK maintainers and the A2A repo maintainers to the project maintainer roster.