### PR TITLE
docs(blog): show post excerpts with 'Continue reading' on blog index

### DIFF
--- a/.mkdocs/overrides/main.html
+++ b/.mkdocs/overrides/main.html
@@ -1,8 +1,15 @@
 {% extends "base.html" %}
 
 {% block announce %}
+  <span>New on the blog: <b>A2A joins the Agentic AI Foundation</b></span>
+  <a href="https://a2a-protocol.org/latest/blog/2026/08/27/a-new-chapter-for-a2a-joining-the-agentic-ai-foundation/" class="md-button">
+    Read the announcement
+  </a>
+
+  <!-- Previous announcement — kept for reference:
   <span>Join the DeepLearning.AI course to explore the <b>A2A Protocol</b></span>
   <a href="https://www.deeplearning.ai/courses/a2a-the-agent2agent-protocol" class="md-button">
     Enroll for free
   </a>
+  -->
 {% endblock %}

--- a/docs/blog/posts/a2a-joins-aaif.md
+++ b/docs/blog/posts/a2a-joins-aaif.md
@@ -9,6 +9,8 @@ categories:
 
 The Agent2Agent (A2A) protocol has officially been accepted as a Growth Stage project at the Agentic AI Foundation (AAIF). By joining the AAIF's open agentic stack, A2A provides an open standard for how autonomous AI agents discover each other, delegate tasks, and collaborate across distinct frameworks and vendor boundaries.
 
+<!-- more -->
+
 ## The Horizontal Orchestration Layer
 
 While the Model Context Protocol (MCP) serves as the vertical integration layer connecting agents to internal tools and databases, A2A acts as the horizontal protocol enabling peer-to-peer collaboration. Before A2A, handing off work between agents built on different frameworks required writing custom integration code from scratch for every new pairing. Today, an agent can publish a structured "agent card" detailing its capabilities and contact methods, allowing other independent agents to securely read it, negotiate modalities, and delegate tasks without manual intervention.

--- a/docs/blog/posts/announcing-1.0.md
+++ b/docs/blog/posts/announcing-1.0.md
@@ -11,6 +11,8 @@ The A2A Protocol community today are announcing the release of A2A Protocol v1.0
 
 As organizations build increasingly sophisticated multi-agent systems, interoperability has become the defining challenge. Teams can coordinate agents effectively within a single platform, but connecting those systems across technology stacks and organizational boundaries remains difficult. A2A addresses that challenge by combining support for multiple protocol bindings, seamless version negotiation, and a common semantic model so agents can interoperate across systems with predictable behavior.
 
+<!-- more -->
+
 The v1.0 release emphasizes maturity rather than reinvention: the core ideas remain intact, while rough edges have been removed, ambiguous areas clarified, and enterprise deployment requirements addressed more directly. The official SDKs ensure v1.0 A2A agents work seamlessly with older versions.
 
 ## Delivering on enterprise requirements

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -164,7 +164,7 @@ markdown_extensions:
 plugins:
   - blog:
       post_url_format: "{date}/{slug}"
-      pagination_per_page: 1
+      pagination_per_page: 2
   - search
   - macros:
       module_name: .mkdocs/macros


### PR DESCRIPTION
Update the blog main to show 2 posts at once. By showing only 1 post, post the page feels duplicate. With only 1 post, both the blog post and post's own page page show same content.

- mkdocs.yml: bump blog pagination_per_page `1` -> `2` so the index shows the two most recent posts.
- Add a `<!-- more -->` hidden excerpt separator after the intro paragraph of each post so the index shows a few lines plus a 'Continue reading' link.