### PR TITLE
docs: add x402-list to partners

### DIFF
--- a/docs/partners.md
+++ b/docs/partners.md
@@ -172,6 +172,7 @@ collaborate effectively with each other and with users.
 - [Workday](https://www.workday.com)
 - [WritBase](https://github.com/Writbase/writbase)
 - [Writer](https://writer.com)
+- [x402-list](https://x402-list.com)
 - [Zenity](https://zenity.io)
 - [Zeotap](https://www.zeotap.com)
 - [Zocket Technologies , Inc.](https://zocket.ai)


### PR DESCRIPTION
Adds x402-list to the A2A partners list.

x402-list is an agent-first directory of x402 payment endpoints: it helps
agents discover and verify payable APIs (including the A2A x402 extension
flow) before paying. Homepage: https://x402-list.com

Entry inserted alphabetically between "Writer" and "Zenity", following the
existing `- [Name](url)` list format.
