### PR TITLE
ci(docs): bind workflow_dispatch version under env, not inline

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -139,10 +139,12 @@ jobs:
       - name: Manually deploy specific version from main
         if: github.event_name == 'workflow_dispatch'
         run: |
-          mike deploy --push --update-aliases ${{ github.event.inputs.version }} latest
+          mike deploy --push --update-aliases "$MIKE_VERSION" latest
 
           echo "Setting 'latest' as the default version for the site..."
           mike set-default --push latest
 
           # Re-deploy 404 page
           bash scripts/deploy_root_files.sh ${{ github.repository }} ${{ secrets.GITHUB_TOKEN }}
+        env:
+          MIKE_VERSION: ${{ github.event.inputs.version }}


### PR DESCRIPTION
## Summary

Fixes #2110. The manual-deploy step in `.github/workflows/docs.yml` interpolated `github.event.inputs.version` directly into a `run:` script:

```yaml
run: |
  mike deploy --push --update-aliases ${{ github.event.inputs.version }} latest
```

The release step in the same file already binds its equivalent value under `env:` before referencing it as a quoted shell variable:

```yaml
run: |
  export MIKE_VERSION=${GITHUB_EVENT_RELEASE_TAG_NAME}
  mike deploy --push --update-aliases $MIKE_VERSION latest
env:
  GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
```

`workflow_dispatch` inputs are attacker-controllable by anyone with permission to trigger the workflow, so inline-interpolating one into a `run:` script text is a script-injection surface (GitHub's own Actions security hardening guidance calls this out explicitly). The `env:`-binding pattern used elsewhere in this same file avoids it, since the untrusted value never gets substituted into the script text — it's passed as an environment variable instead.

## Change

Binds `github.event.inputs.version` under `env: MIKE_VERSION` and references it as `"$MIKE_VERSION"` (quoted) in the manual-deploy step, matching the release step's existing pattern exactly. No functional change to what gets deployed.

## Testing Plan

- `.github/workflows/docs.yml` parses as valid YAML (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/docs.yml'))"`).
- Diff is a 1-line change plus a 2-line `env:` addition — no other workflow behavior touched.
- CI hygiene fix, not filed as a vulnerability advisory (per the issue).