### PR TITLE
docs(spec): note the v1.0.1 error-mapping table correction

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1189,6 +1189,8 @@ All A2A-specific errors defined in [Section 3.3.2](#332-error-handling) **MUST**
 | `ExtensionSupportRequiredError`       | `-32008`      | `FAILED_PRECONDITION` | `400 Bad Request`           |
 | `VersionNotSupportedError`            | `-32009`      | `FAILED_PRECONDITION` | `400 Bad Request`           |
 
+> **Note:** Six cells in this table were corrected in the `v1.0.1` patch release to align with [`google.rpc.Code`](https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto)-defined mappings ([#1627](https://github.com/a2aproject/A2A/pull/1627)). The `v1.0.0` values were: `TaskNotCancelableError` HTTP Status `409 Conflict`; `PushNotificationNotSupportedError` gRPC Status `UNIMPLEMENTED`; `UnsupportedOperationError` gRPC Status `UNIMPLEMENTED`; `ContentTypeNotSupportedError` HTTP Status `415 Unsupported Media Type`; `InvalidAgentResponseError` HTTP Status `502 Bad Gateway`; `VersionNotSupportedError` gRPC Status `UNIMPLEMENTED`. An implementation built against the `v1.0.0` table should be updated to match the table above.
+
 **Custom Binding Requirements:**
 
 Custom protocol bindings **MUST** define equivalent error code mappings that preserve the semantic meaning of each A2A error type. The binding specification **SHOULD** provide a similar mapping table showing how each A2A error type is represented in the custom binding's native error format.


### PR DESCRIPTION
## Summary

Fixes #2200. Six cells in the §5.4 error-mapping table changed between `v1.0.0` and `v1.0.1` — both HTTP and gRPC statuses, both wire-observable — when `757f0ec` ("fix(spec): recent transcoding-related error changes", #1627) aligned them with `google.rpc.Code`-defined mappings:

| Error | `v1.0.0` | `v1.0.1` |
|---|---|---|
| `TaskNotCancelableError` | `409 Conflict` | `400 Bad Request` |
| `PushNotificationNotSupportedError` | `UNIMPLEMENTED` | `FAILED_PRECONDITION` |
| `UnsupportedOperationError` | `UNIMPLEMENTED` | `FAILED_PRECONDITION` |
| `ContentTypeNotSupportedError` | `415 Unsupported Media Type` | `400 Bad Request` |
| `InvalidAgentResponseError` | `502 Bad Gateway` | `500 Internal Server Error` |
| `VersionNotSupportedError` | `UNIMPLEMENTED` | `FAILED_PRECONDITION` |

(Verified directly against `git show v1.0.0:docs/specification.md` vs `v1.0.1:docs/specification.md`.)

Nothing in `docs/` recorded that this table had moved, and §3.6 says patch version numbers "MUST not be considered when clients and servers negotiate protocol versions" — so a `v1.0.0`-conformant server and a `v1.0.1`-conformant one disagree on the wire with no way for either side to tell, and no signal for an implementer reading "A2A 1.0" today to notice which table their reference implementation was built from. Two independent implementations found this by testing against a different implementation, not by reading anything: `a2aproject/a2a-tck` (the project's own conformance kit, still grading against the `v1.0.0` table — filed separately as a2aproject/a2a-tck#231) and a third-party `a2a-rust` implementation.

## Scope

This does **not** resolve the broader §3.6 question — whether a patch release should be allowed to change wire-observable behavior at all, and how that interacts with the versioning guarantee's text — which is a separate, normative discussion the issue also raises. #2200 explicitly lists two independent remediations, either sufficient on its own; this implements the smaller one: **a note under §5.4 recording that the table changed, listing the prior values, and pointing at the PR that changed them**, so the divergence is self-diagnosing for anyone auditing an older implementation against this document.

## Change

One `> **Note:**` block added immediately after the §5.4 table, before "Custom Binding Requirements." No table rows, MUST-level text, or other spec content changed.

## Testing Plan

- Values cross-checked directly against `git show v1.0.0:docs/specification.md` and `v1.0.1:docs/specification.md` (not transcribed from the issue).
- `npx markdownlint-cli docs/specification.md --config .github/linters/.markdownlint.json` — clean.
- `git diff` is a 2-line addition; no other content touched.