### PR TITLE
docs: improve readability and wording in a2a-and-mcp

### DIFF
--- a/docs/topics/a2a-and-mcp.md
+++ b/docs/topics/a2a-and-mcp.md
@@ -5,9 +5,32 @@ interoperability. One connects agents to tools and resources. The other enables
 agent-to-agent collaboration. The Agent2Agent (A2A) Protocol and the
 [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) address these distinct but highly complementary needs.
 
+## Horizontal and Vertical Layers
+
+One way to picture the two protocols is by the direction they connect in.
+
+**MCP is vertical.** It deepens a single agent. You can build an agentic system
+under one roof — one or more agents in a single application. Every MCP connection
+you add hands an agent another tool, resource, or skill. The more you connect,
+the more that agent can do on its own.
+
+**A2A is horizontal.** It connects agents across that boundary. The other agent
+may belong to another team, another department, or a partner organization. Your
+agent reaches out to those agents to discover them, negotiate, and exchange
+information.
+
+That horizontal reach goes beyond asking another agent for a status update. It is
+closer to how one person reaches out to another for help: _"Are you working on
+this project? Do you know about it? Can you share what you have — and if not,
+which agent can?"_ Agents break the ice, exchange context, and — depending on how
+the exchange goes — either go deeper or get pointed to a better place to get the
+job done.
+
+Used together, MCP gives each agent depth, and A2A gives your system reach.
+
 ## Model Context Protocol
 
-The Model Context Protocol (MCP) defines how an AI agent interacts with and utilizes individual tools and resources, such as a database or an API.
+The Model Context Protocol (MCP) defines how an AI agent uses individual tools and resources, such as a database or an API.
 
 This protocol offers the following capabilities:
 
@@ -21,22 +44,22 @@ This protocol offers the following capabilities:
 
 ## Agent2Agent Protocol
 
-The Agent2Agent Protocol focuses on enabling different agents to collaborate with one another to achieve a common goal.
+The Agent2Agent Protocol lets different agents collaborate to reach a common goal.
 
 This protocol offers the following capabilities:
 
 - Standardizes how independent, often opaque, AI agents communicate and
   collaborate as peers.
-- Provides an application-level protocol for agents to discover each other,
-  negotiate interactions, manage shared tasks, and exchange conversational
-  context and complex data.
-- Supports typical use cases, including a customer service agent delegating an
-  inquiry to a billing agent, or a travel agent coordinating with flight,
+- Gives agents an application-level protocol. With it, agents discover each
+  other and negotiate interactions. They also manage shared tasks and exchange
+  conversational context and complex data.
+- Supports common use cases. For example, a customer service agent might delegate
+  an inquiry to a billing agent. A travel agent might coordinate with flight,
   hotel, and activity agents.
 
 ## Why Different Protocols?
 
-Both the MCP and A2A protocols are essential for building complex AI systems, and they address distinct but highly complementary needs. The distinction between A2A and MCP depends on what an agent interacts with.
+Both protocols are essential for building complex AI systems. The distinction between A2A and MCP depends on what an agent interacts with.
 
 - **Tools and Resources (MCP Domain)**:
       - **Characteristics:** These are typically primitives with well-defined,
@@ -47,48 +70,46 @@ Both the MCP and A2A protocols are essential for building complex AI systems, an
         functions.
 - **Agents (A2A domain)**:
       - **Characteristics:** These are more autonomous systems. They reason,
-        plan, use multiple tools, maintain state over longer interactions, and
-        engage in complex, often multi-turn dialogues to achieve novel or
-        evolving tasks.
+        plan, and use multiple tools. They keep state over longer interactions
+        and hold complex, often multi-turn dialogues to handle novel or evolving
+        tasks.
       - **Purpose:** Agents collaborate with other agents to tackle broader, more
         complex goals.
 
 ## A2A ❤️ MCP: Complementary Protocols for Agentic Systems
 
-An agentic application might primarily use A2A to communicate with other agents.
-Each individual agent internally uses MCP to interact with its specific tools
-and resources.
+An agentic application might use A2A to communicate with other agents. Inside,
+each agent uses MCP to work with its own tools and resources.
 
 <div style="text-align: center; margin: 20px;" markdown>
 
 ![Diagram showing A2A and MCP working together. A User interacts with Agent A using A2A. Agent A interacts with Agent B using A2A. Agent B uses MCP to interact with Tool 1 and Tool 2.](../assets/a2a-mcp.png){width="80%"}
 
-_An agentic application might use A2A to communicate with other agents, while each agent internally uses MCP to interact with its specific tools and resources._
+_A2A connects the agents to each other; MCP connects each agent to its own tools._
 
 </div>
 
 ### Example Scenario: The Auto Repair Shop
 
 Consider an auto repair shop staffed by autonomous AI agent "mechanics".
-These mechanics use special-purpose tools, such as vehicle diagnostic scanners,
-repair manuals, and platform lifts, to diagnose and repair problems. The repair
-process can involve extensive conversations, research, and interaction with part
+These mechanics diagnose and repair problems with special-purpose tools. Their
+tools include vehicle diagnostic scanners, repair manuals, and platform lifts.
+The repair process can involve long conversations, research, and work with part
 suppliers.
 
-- **Customer Interaction (User-to-Agent using A2A)**: A customer (or their
-    primary assistant agent) uses A2A to communicate with the "Shop Manager"
-    agent.
+- **Customer interaction — user-to-agent via A2A.** A customer, or their
+    assistant agent, talks to the "Shop Manager" agent.
 
     For example, the customer might say, "My car is making a rattling noise".
 
-- **Multi-turn Diagnostic Conversation (Agent-to-Agent using A2A)**: The Shop
-    Manager agent uses A2A for a multi-turn diagnostic conversation.
+- **Diagnostic conversation — agent-to-agent via A2A.** The Shop Manager agent
+    holds a back-and-forth diagnostic conversation.
 
     For example, the Manager might ask, "Can you send a video of the noise?" or "I see some fluid leaking. How long has this been happening?".
 
-- **Internal Tool Usage (Agent-to-Tool using MCP)**: The Mechanic agent,
-    assigned the task by the Shop Manager, needs to diagnose the issue. The
-    Mechanic agent uses MCP to interact with its specialized tools.
+- **Internal tool use — agent-to-tool via MCP.** The Mechanic agent, assigned
+    the task by the Shop Manager, needs to diagnose the issue. It uses MCP to
+    reach its specialized tools.
 
     For example:
 
@@ -99,34 +120,27 @@ suppliers.
         vehicle_model='Camry')`
     - MCP call to a "Platform Lift" tool: `raise_platform(height_meters=2)`
 
-- **Supplier Interaction (Agent-to-Agent using A2A)**: The Mechanic agent
-    determines that a specific part is needed. The Mechanic agent uses A2A to
-    communicate with a "Parts Supplier" agent to order a part.
+- **Supplier interaction — agent-to-agent via A2A.** The Mechanic agent finds
+    that a specific part is needed. It uses A2A to talk to a "Parts Supplier"
+    agent and order the part.
     For example, the
     Mechanic agent might ask, "Do you have part #12345 in stock for a Toyota Camry 2018?"
 
-- **Order processing (Agent-to-Agent using A2A)**: The Parts Supplier agent,
-    which is also an A2A-compliant system, responds, potentially leading to an
-    order.
+- **Order processing — agent-to-agent via A2A.** The Parts Supplier agent is
+    also an A2A-compliant system. It responds, which can lead to an order.
 
 In this example:
 
-- A2A facilitates the higher-level, conversational, and task-oriented
-    interactions between the customer and the shop, and between the shop's
-    agents and external supplier agents.
+- A2A handles the higher-level, conversational, task-oriented interactions. It
+    links the customer with the shop, and the shop's agents with outside supplier
+    agents.
 - MCP enables the mechanic agent to use its specific, structured tools to
     perform its diagnostic and repair functions.
 
-An A2A server could expose some of its skills as MCP-compatible resources.
-However, A2A's primary strength lies in its support for more flexible, stateful,
-and collaborative interactions. These interactions go beyond a typical tool
-invocation. A2A focuses on agents partnering on tasks, whereas MCP focuses on
-agents using capabilities.
-
 ## Representing A2A Agents as MCP Resources
 
-An A2A Server (a remote agent) could expose some of its skills as MCP-compatible resources, especially if those skills are well-defined and can be invoked in a more tool-like, stateless manner. In such a case, another agent might "discover" this A2A agent's specific skill through an MCP-style tool description (perhaps derived from its Agent Card).
+An A2A Server (a remote agent) can expose some skills as MCP-compatible resources. This works best when the skills are well-defined and can be called in a tool-like, stateless way. Another agent might then "discover" the skill through an MCP-style tool description, perhaps derived from the Agent Card.
 
-However, the primary strength of A2A lies in its support for more flexible, stateful, and collaborative interactions that go beyond typical tool invocation. A2A is about agents _partnering_ on tasks, while MCP is more about agents _using_ capabilities.
+Still, A2A's main strength is its support for flexible, stateful, collaborative interactions that go beyond a typical tool call. A2A is about agents _partnering_ on tasks; MCP is more about agents _using_ capabilities.
 
-By leveraging both A2A for inter-agent collaboration and MCP for tool integration, developers can build more powerful, flexible, and interoperable AI systems.
+Use both together. A2A handles inter-agent collaboration and MCP handles tool integration. This lets you build more powerful, flexible, and interoperable AI systems.


### PR DESCRIPTION
## Summary
Readability + wording pass on `docs/topics/a2a-and-mcp.md` (quillscore grade C → A).

- Clearer prose; A2A/MCP framed as complementary, never competitive
- Kept "Horizontal and Vertical Layers" framing (MCP = depth, A2A = reach)
- Auto Repair Shop bullets restyled to `**Label — X via Y.**`